### PR TITLE
Implement final results page

### DIFF
--- a/app/src/main/kotlin/com/example/itemidentifier/MainActivity.kt
+++ b/app/src/main/kotlin/com/example/itemidentifier/MainActivity.kt
@@ -15,6 +15,7 @@ import com.example.itemidentifier.navigation.Screen
 import com.example.itemidentifier.ui.screens.BrandScreen
 import com.example.itemidentifier.ui.screens.CategoryScreen
 import com.example.itemidentifier.ui.screens.DiagnosticFunnelScreen
+import com.example.itemidentifier.ui.screens.FinalResultsScreen
 import com.example.itemidentifier.ui.screens.ModelScreen
 import com.example.itemidentifier.ui.theme.ItemIdentifierTheme
 import com.example.itemidentifier.viewmodel.MainViewModel
@@ -66,8 +67,14 @@ class MainActivity : ComponentActivity() {
                             val modelId = backStackEntry.arguments?.getString("modelId")!!
                             DiagnosticFunnelScreen(
                                 viewModel = viewModel,
-                                modelId = modelId
+                                modelId = modelId,
+                                onNavigateToResults = {
+                                    navController.navigate(Screen.FinalResults.route)
+                                }
                             )
+                        }
+                        composable(Screen.FinalResults.route) {
+                            FinalResultsScreen(viewModel = viewModel)
                         }
                     }
                 }

--- a/app/src/main/kotlin/com/example/itemidentifier/navigation/Screen.kt
+++ b/app/src/main/kotlin/com/example/itemidentifier/navigation/Screen.kt
@@ -11,4 +11,5 @@ sealed class Screen(val route: String) {
     object DiagnosticFunnel : Screen("funnel/{modelId}") {
         fun createRoute(modelId: String) = "funnel/$modelId"
     }
+    object FinalResults : Screen("results")
 }

--- a/app/src/main/kotlin/com/example/itemidentifier/ui/screens/DiagnosticFunnelScreen.kt
+++ b/app/src/main/kotlin/com/example/itemidentifier/ui/screens/DiagnosticFunnelScreen.kt
@@ -10,22 +10,18 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
 import coil.compose.AsyncImage
 import com.example.itemidentifier.viewmodel.MainViewModel
-import com.example.itemidentifier.viewmodel.RiskTier
 
 @Composable
 fun DiagnosticFunnelScreen(
     viewModel: MainViewModel,
-    modelId: String
+    modelId: String,
+    onNavigateToResults: () -> Unit
 ) {
     val checklist by viewModel.checklist.collectAsState()
     val currentQuestionIndex by viewModel.currentQuestionIndex.collectAsState()
-    val riskScore by viewModel.riskScore.collectAsState()
-    val riskTier by viewModel.riskTier.collectAsState()
     val assessmentHalted by viewModel.assessmentHalted.collectAsState()
 
     LaunchedEffect(modelId) {
@@ -91,28 +87,9 @@ fun DiagnosticFunnelScreen(
                 }
             }
         } else {
-            FunnelResultsScreen(riskScore = riskScore, riskTier = riskTier, assessmentHalted = assessmentHalted)
+            LaunchedEffect(Unit) {
+                onNavigateToResults()
+            }
         }
-    }
-}
-
-@Composable
-fun FunnelResultsScreen(riskScore: Int, riskTier: RiskTier, assessmentHalted: Boolean) {
-    Column(
-        modifier = Modifier
-            .fillMaxSize()
-            .padding(16.dp),
-        horizontalAlignment = Alignment.CenterHorizontally,
-        verticalArrangement = Arrangement.Center
-    ) {
-        if (assessmentHalted) {
-            Text(text = "Assessment Halted!", fontSize = 24.sp, color = Color.Red)
-            Spacer(modifier = Modifier.height(16.dp))
-        }
-        Text(text = "Funnel Complete!", fontSize = 24.sp)
-        Spacer(modifier = Modifier.height(16.dp))
-        Text(text = "Final Score: $riskScore", fontSize = 20.sp)
-        Spacer(modifier = Modifier.height(8.dp))
-        Text(text = "Risk Tier: $riskTier", fontSize = 20.sp)
     }
 }

--- a/app/src/main/kotlin/com/example/itemidentifier/ui/screens/FinalResultsScreen.kt
+++ b/app/src/main/kotlin/com/example/itemidentifier/ui/screens/FinalResultsScreen.kt
@@ -1,0 +1,120 @@
+package com.example.itemidentifier.ui.screens
+
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.Card
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import coil.compose.AsyncImage
+import com.example.itemidentifier.data.Answer
+import com.example.itemidentifier.viewmodel.MainViewModel
+
+@Composable
+fun FinalResultsScreen(viewModel: MainViewModel) {
+    val riskScore by viewModel.riskScore.collectAsState()
+    val riskTier by viewModel.riskTier.collectAsState()
+    val userAnswers by viewModel.userAnswers.collectAsState()
+    val checklist by viewModel.checklist.collectAsState()
+
+    LazyColumn(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(16.dp)
+    ) {
+        item {
+            Column(horizontalAlignment = Alignment.CenterHorizontally, modifier = Modifier.fillMaxWidth()) {
+                Text("Final Results", fontSize = 24.sp, fontWeight = FontWeight.Bold)
+                Spacer(modifier = Modifier.height(16.dp))
+                Text("Risk Score: $riskScore", fontSize = 20.sp)
+                Text("Risk Tier: $riskTier", fontSize = 20.sp, fontWeight = FontWeight.Bold)
+                Spacer(modifier = Modifier.height(16.dp))
+            }
+        }
+
+        item {
+            Text("Answer Log", fontSize = 20.sp, fontWeight = FontWeight.Bold)
+            Spacer(modifier = Modifier.height(8.dp))
+        }
+
+        items(userAnswers.toList()) { (question, answer) ->
+            AnswerLogItem(question = question, answer = answer)
+        }
+
+        item {
+            Spacer(modifier = Modifier.height(16.dp))
+            Text("Red Flag Summary", fontSize = 20.sp, fontWeight = FontWeight.Bold)
+            Spacer(modifier = Modifier.height(8.dp))
+        }
+
+        val redFlags = userAnswers.filter { (_, answer) -> answer.flag != "None" }
+        if (redFlags.isEmpty()) {
+            item {
+                Text("No red flags identified.")
+            }
+        } else {
+            items(redFlags.toList()) { (question, answer) ->
+                val questionDetails = checklist?.checklist?.find { it.question == question }
+                RedFlagItem(question = question, answer = answer, authenticImage = questionDetails?.authentic_image ?: "", inauthenticImage = questionDetails?.inauthentic_image ?: "")
+            }
+        }
+
+        item {
+            Spacer(modifier = Modifier.height(16.dp))
+            DisclaimerAndAdvice()
+        }
+    }
+}
+
+@Composable
+fun AnswerLogItem(question: String, answer: Answer) {
+    Card(modifier = Modifier.fillMaxWidth().padding(vertical = 4.dp)) {
+        Column(modifier = Modifier.padding(16.dp)) {
+            Text(question, fontWeight = FontWeight.Bold)
+            Text("Your answer: ${answer.text} (Score: ${answer.score}, Flag: ${answer.flag})")
+        }
+    }
+}
+
+@Composable
+fun RedFlagItem(question: String, answer: Answer, authenticImage: String, inauthenticImage: String) {
+    Card(modifier = Modifier.fillMaxWidth().padding(vertical = 4.dp)) {
+        Column(modifier = Modifier.padding(16.dp)) {
+            Text(question, fontWeight = FontWeight.Bold)
+            Text("Your answer: ${answer.text}", color = Color.Red)
+            Text("Flag: ${answer.flag}", color = Color.Red, fontWeight = FontWeight.Bold)
+            Spacer(modifier = Modifier.height(8.dp))
+            Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.SpaceEvenly) {
+                Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                    Text("Authentic")
+                    AsyncImage(model = authenticImage, contentDescription = "Authentic Image", modifier = Modifier.size(128.dp))
+                }
+                Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                    Text("Inauthentic")
+                    AsyncImage(model = inauthenticImage, contentDescription = "Inauthentic Image", modifier = Modifier.size(128.dp))
+                }
+            }
+        }
+    }
+}
+
+@Composable
+fun DisclaimerAndAdvice() {
+    Card(modifier = Modifier.fillMaxWidth().padding(vertical = 4.dp)) {
+        Column(modifier = Modifier.padding(16.dp)) {
+            Text("Disclaimer", fontSize = 20.sp, fontWeight = FontWeight.Bold)
+            Text("This is a preliminary self-assessment tool. The results are not a guarantee of authenticity. For a definitive evaluation, please consult a professional authenticator.")
+            Spacer(modifier = Modifier.height(16.dp))
+            Text("Actionable Advice", fontSize = 20.sp, fontWeight = FontWeight.Bold)
+            Text("We strongly recommend seeking a final evaluation from a professional authenticator, especially if any red flags were identified.")
+        }
+    }
+}

--- a/app/src/main/kotlin/com/example/itemidentifier/viewmodel/MainViewModel.kt
+++ b/app/src/main/kotlin/com/example/itemidentifier/viewmodel/MainViewModel.kt
@@ -42,7 +42,8 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
     private val _assessmentHalted = MutableStateFlow(false)
     val assessmentHalted: StateFlow<Boolean> = _assessmentHalted
 
-    private val userAnswers = mutableMapOf<String, Answer>()
+    private val _userAnswers = MutableStateFlow<Map<String, Answer>>(emptyMap())
+    val userAnswers: StateFlow<Map<String, Answer>> = _userAnswers
 
     fun getBrands() {
         viewModelScope.launch {
@@ -66,7 +67,7 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
         viewModelScope.launch {
             _checklist.value = repository.getChecklist(brand, category, model)
             _currentQuestionIndex.value = 0
-            userAnswers.clear()
+            _userAnswers.value = emptyMap()
             _riskScore.value = 0
             _riskTier.value = RiskTier.Undetermined
             _assessmentHalted.value = false
@@ -76,7 +77,7 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
     fun answerQuestion(question: String, answer: Answer) {
         if (_assessmentHalted.value) return
 
-        userAnswers[question] = answer
+        _userAnswers.value = _userAnswers.value + (question to answer)
         _riskScore.value += answer.score
 
         Log.d("MainViewModel", "User answered question: '$question' with '${answer.text}' -> score: ${answer.score}, flag: ${answer.flag}")


### PR DESCRIPTION
This commit introduces the final results page, which is displayed at the end of the diagnostic workflow.

The page includes a comprehensive summary of the assessment, including:
- The final risk score and corresponding risk tier.
- A complete log of the user's answers.
- A detailed breakdown of each identified red flag with reference images.
- A disclaimer and actionable advice section.

This completes the core functionality of the interactive diagnostic funnel.