### PR TITLE
Fix: Remove resource grants from developer mode

### DIFF
--- a/index.html
+++ b/index.html
@@ -3457,10 +3457,6 @@ function openProductAssignmentForShelf(shelf, slotIndex) {
             devToggle.checked = developerMode;
             devToggle.addEventListener('change', (e) => {
                 developerMode = e.target.checked;
-                if (developerMode) {
-                    cash = 99999;
-                    shopPoints = 999;
-                }
                 updateUI();
             });
             const continuousToggle = document.getElementById('continuous-toggle');


### PR DESCRIPTION
This change modifies the developer mode feature. Previously, enabling developer mode would grant the player a large amount of cash and shop points.

This commit removes that functionality, so that developer mode now only makes all unlockables free, without directly granting any resources to the player. This is more suitable for testing purposes as it doesn't skew the in-game economy.