### PR TITLE
fix: Prevent stale game state save on starring customer

### DIFF
--- a/index.html
+++ b/index.html
@@ -2898,7 +2898,6 @@
                     const profile = customerProfiles[report.typeKey][report.name];
                     profile.isStarred = !profile.isStarred;
                     e.target.textContent = profile.isStarred ? '⭐' : '☆';
-                    saveGame();
                 });
             });
 


### PR DESCRIPTION
This commit fixes a bug where starring a customer on the end-of-day report would cause no customers to spawn on subsequent days.

The issue was caused by an immediate `saveGame()` call within the star button's event listener. This saved the customer's profile with the `visitedToday` flag still set to `true`, effectively locking them out from visiting again.

By removing this premature `saveGame()` call, the "starred" status is now saved along with all other game data at the start of the next day, ensuring the `visitedToday` flag is correctly reset and customers can spawn as expected.