### PR TITLE
Fix: Ensure customer `visitedToday` flags are reset at end of day

### DIFF
--- a/index.html
+++ b/index.html
@@ -2878,13 +2878,17 @@
             document.getElementById('report-expenses').textContent = `-$${dailyExpenses}`;
             document.getElementById('report-profit').textContent = `$${grossSales - dailyExpenses}`;
             reportPanel.classList.remove('hidden');
+
+            // Reset visited flags as soon as the day ends to prevent save/load issues.
+            for (const type in customerProfiles) {
+                for (const name in customerProfiles[type]) {
+                    customerProfiles[type][name].visitedToday = false;
+                }
+            }
+            saveGame(); // Persist the reset state immediately.
+
             document.getElementById('next-day-report-btn').onclick = () => {
                 day++;
-                for (const type in customerProfiles) {
-                    for (const name in customerProfiles[type]) {
-                        customerProfiles[type][name].visitedToday = false;
-                    }
-                }
                 Object.keys(inventory).forEach(item => {
                     if (inventory[item] < 5) inventory[item] += 1;
                 });


### PR DESCRIPTION
This change fixes a bug where customers would not spawn after the first day if the game was reloaded from the end-of-day report screen.

The `visitedToday` flag for each customer was previously only reset when the "Start Next Day" button was clicked. This created a state management issue where reloading the game before clicking the button would cause the game to save with the flags still set to `true`.

The fix moves the reset logic to the main `nextDay` function, so it executes as soon as the day ends. An immediate `saveGame()` call is also added to persist this correct state, making the day transition robust against unexpected reloads.