### PR TITLE
feat: add back button and escape key functionality to phone UI

### DIFF
--- a/index.html
+++ b/index.html
@@ -284,7 +284,10 @@
                 </div>
 
                 <!-- Phone Footer / Close Button -->
-                <div class="pt-4 mt-auto text-center">
+                <div class="pt-4 mt-auto flex justify-center items-center space-x-12">
+                    <button id="phone-back-btn" class="text-gray-400 hover:text-white transition-colors">
+                        <svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"><path d="M19 12H5"/><path d="m12 19-7-7 7-7"/></svg>
+                    </button>
                      <button id="close-phone" class="w-24 h-1.5 bg-gray-500 rounded-full hover:bg-gray-400 transition-colors"></button>
                 </div>
             </div>
@@ -701,6 +704,10 @@
                 openUnlocksPanel();
             } else if (e.code === 'KeyE') {
                 handleInteraction();
+            } else if (e.code === 'Escape') {
+                if (activePanel) {
+                    togglePanel(activePanel, false);
+                }
             }
         });
 
@@ -4666,6 +4673,7 @@ function openProductAssignmentForShelf(shelf, slotIndex) {
                     closeButton.addEventListener('click', () => togglePanel(panelName, false));
                 }
             });
+            document.getElementById('phone-back-btn').addEventListener('click', () => togglePanel('phone', false));
 
             // Settings Toggles
             const devToggle = document.getElementById('developer-toggle');


### PR DESCRIPTION
This commit enhances the phone UI by adding two new navigation features:

- A visible back button has been added to the phone's footer, which allows users to close the phone menu with a click.
- A global event listener for the 'Escape' key has been implemented. Pressing 'Escape' will now close any currently active panel, providing a quick and intuitive way to navigate back in the UI.