### PR TITLE
feat: Implement weekly failure condition and align packages

### DIFF
--- a/index.html
+++ b/index.html
@@ -1164,7 +1164,7 @@
 
         function drawPackages() {
             loadingDockPackages.forEach((pkg, index) => {
-                const x = 10 + index * (PACKAGE_WIDTH + 10);
+                const x = loadingDock.x + 10 + index * (PACKAGE_WIDTH + 10);
                 const y = loadingDock.y + (loadingDock.height - PACKAGE_HEIGHT) / 2;
                 drawPackage(pkg, x, y);
             });
@@ -3141,9 +3141,10 @@
             saveGame();
         }
 
-        function endGame() {
+        function endGame(reason) {
             running = false;
-            showMessage(`Game Over! You ran out of money. You survived for ${day} days and ended with $${Math.round(cash)}.`, null);
+            const defaultMessage = `Game Over! You ran out of money. You survived for ${day} days and ended with $${Math.round(cash)}.`;
+            showMessage(reason || defaultMessage, null);
         }
 
         function nextDay() {
@@ -3167,11 +3168,13 @@
             cash -= dailyExpenses;
             customers.forEach(c => c.state = 'leaving');
             timeSinceLastCustomer = 0;
-            if (cash < 0) {
+
+            if (day > 0 && day % 7 === 0 && cash < 0) {
                 updateUI();
-                endGame();
+                endGame(`Game Over! You couldn't pay your weekly bills and ended with a debt of $${Math.abs(cash).toFixed(2)}.`);
                 return;
             }
+
             updateUI();
             const reportPanel = document.getElementById('end-of-day-panel');
             const reportList = document.getElementById('sales-report-list');


### PR DESCRIPTION
This commit introduces a new weekly failure condition and adjusts the alignment of loading dock packages.

The game no longer ends immediately if the player's cash goes below zero. Instead, a check is performed at the end of every 7th day. If the cash is negative at that point, the game ends. This allows the player to operate with a negative balance during the week.

Additionally, the packages that arrive at the loading dock are now correctly aligned with the loading dock area, ensuring they are only visible in the main store view.