### PR TITLE
feat: Filter available items on shelf assignment screen

### DIFF
--- a/index.html
+++ b/index.html
@@ -4554,7 +4554,16 @@ function openProductAssignmentForShelf(shelf, slotIndex) {
             };
             assignmentGrid.appendChild(clearButton);
 
-            for (const itemName in items) {
+            const unlockedItems = new Set();
+            storageCells.forEach((cell, index) => {
+                if (unlocks.storage[index]) {
+                    cell.allowedItems.forEach(item => unlockedItems.add(item));
+                }
+            });
+            storageCells[0].allowedItems.forEach(item => unlockedItems.add(item));
+
+
+            for (const itemName of unlockedItems) {
                 const button = document.createElement('button');
                 button.className = 'btn-style';
                 button.textContent = itemName;


### PR DESCRIPTION
This commit updates the shelf assignment screen to only display items that the player has unlocked through storage upgrades.

The `openProductAssignmentForShelf` function has been modified to:
1.  Build a set of `unlockedItems` by checking which storage units have been unlocked by the player.
2.  Iterate over this set of `unlockedItems` instead of the global `items` object when creating the assignment buttons.

This change ensures that players can only assign items to shelves if they have unlocked the corresponding storage type, preventing them from accessing items they shouldn't have yet.