### PR TITLE
Fix: Correct cashier counter position to fix rendering issue

### DIFF
--- a/index.html
+++ b/index.html
@@ -3359,8 +3359,8 @@
                 { label: "Architectural", rect: { x: storeShiftX + canvas.width - cellWidth - cellPadding * 2, y: topPadding + 20, w: cellWidth, h: cellHeight }, allowedItems: ['Pencil Lead', 'Vellum', 'Fancy Markers', 'Tiny Trees'], items: {}, capacity: 50 }
             ];
 
-            cashierCounter.x = storeShiftX + 141;
-            cashierCounter.y = (desk.y - cashierCounter.h) + 141;
+            cashierCounter.x = storeShiftX + 40;
+            cashierCounter.y = (desk.y - cashierCounter.h) + 40;
 
             managersOffice.w = officeWidth;
             managersOffice.h = canvas.height / 2;


### PR DESCRIPTION
The cashier counter was being drawn with incorrect coordinates due to a typo in the `initializeLayout` function. The hardcoded value of `141` was causing the element to be positioned incorrectly, leading to the shop appearing "undrawn".

This commit corrects the typo by changing the value to `40`, which aligns with the positioning logic of other elements in the shop and ensures the cashier counter is drawn in the correct location.