### PR TITLE
feat: Add coffee shop visual to store background

### DIFF
--- a/index.html
+++ b/index.html
@@ -1092,7 +1092,7 @@
             ctx.strokeRect(loadingDock.x, loadingDock.y, loadingDock.width, loadingDock.height-1);
         }
 
-        function drawCoffeeShop(x, y) {
+        function drawCoffeeShop(x, y, shopWidth, shopHeight) {
             const coffeeDarkBrown = '#4a2e1c';
             const coffeeMidBrown = '#6d4c41';
             const coffeeLightBrown = '#a1887f';
@@ -1101,52 +1101,25 @@
             const coffeeSign = '#eaddc7';
             const coffeeText = '#5d4037';
 
-            const shopWidth = 300;
-            const shopHeight = 350;
-
             // Main building structure
             ctx.fillStyle = coffeeLightBrown;
-            ctx.fillRect(x, y - shopHeight, shopWidth, shopHeight);
+            ctx.fillRect(x, y, shopWidth, shopHeight);
 
-            // Roof / Top section
+            // Top decorative beam
+            const roofHeight = shopHeight * 0.08;
             ctx.fillStyle = coffeeMidBrown;
-            ctx.fillRect(x, y - shopHeight, shopWidth, 30);
-
-            // Boxes on top
-            ctx.fillStyle = coffeeMidBrown;
-            ctx.fillRect(x + 20, y - shopHeight - 20, 40, 20);
-            ctx.fillRect(x + 70, y - shopHeight - 20, 40, 20);
-            ctx.fillRect(x + 20, y - shopHeight - 50, 40, 20);
-            ctx.fillRect(x + 70, y - shopHeight - 50, 40, 20);
-            ctx.strokeStyle = coffeeDarkBrown;
-            ctx.lineWidth = 2;
-            ctx.strokeRect(x + 20, y - shopHeight - 20, 40, 20);
-            ctx.strokeRect(x + 70, y - shopHeight - 20, 40, 20);
-            ctx.strokeRect(x + 20, y - shopHeight - 50, 40, 20);
-            ctx.strokeRect(x + 70, y - shopHeight - 50, 40, 20);
-
-            // Grinder
-            ctx.fillStyle = coffeeMidBrown;
-            ctx.fillRect(x + 220, y - shopHeight - 40, 50, 40);
-            ctx.strokeRect(x + 220, y - shopHeight - 40, 50, 40);
-            ctx.fillStyle = coffeeDarkBrown;
-            ctx.fillRect(x + 230, y - shopHeight - 35, 30, 10);
-            ctx.beginPath();
-            ctx.moveTo(x + 245, y - shopHeight - 40);
-            ctx.lineTo(x + 235, y - shopHeight - 60);
-            ctx.lineTo(x + 255, y - shopHeight - 60);
-            ctx.closePath();
-            ctx.fillStyle = coffeeWindow;
-            ctx.fill();
+            ctx.fillRect(x, y, shopWidth, roofHeight);
 
 
             // Coffee Sign
-            const signY = y - shopHeight + 40;
-            const signHeight = 60;
+            const signY = y + shopHeight * 0.1;
+            const signHeight = shopHeight * 0.17;
+            const signX = x + shopWidth * 0.07;
+            const signWidth = shopWidth * 0.86;
             ctx.fillStyle = coffeeSign;
-            ctx.fillRect(x + 20, signY, shopWidth - 40, signHeight);
+            ctx.fillRect(signX, signY, signWidth, signHeight);
             ctx.strokeStyle = coffeeDarkBrown;
-            ctx.strokeRect(x + 20, signY, shopWidth - 40, signHeight);
+            ctx.strokeRect(signX, signY, signWidth, signHeight);
 
             // "Coffee" Text (Pixelated)
             ctx.fillStyle = coffeeText;
@@ -1180,9 +1153,12 @@
             ];
 
             const coffeeTextMap = [letterC, letterO, letterF, letterF, letterE, letterE];
-            const pixelSize = 5;
-            let textX = x + 45;
-            const textY = signY + 18;
+            const pixelSize = Math.max(1, Math.floor(signHeight / 10)); // Make pixel size dynamic
+            const letterWidth = 5 * pixelSize;
+            const letterHeight = 5 * pixelSize;
+            const textBlockWidth = (coffeeTextMap.length * letterWidth) + ((coffeeTextMap.length - 1) * pixelSize * 2);
+            let textX = signX + (signWidth - textBlockWidth) / 2;
+            const textY = signY + (signHeight - letterHeight) / 2;
 
             coffeeTextMap.forEach(letter => {
                 for(let r=0; r<5; r++){
@@ -1192,59 +1168,76 @@
                         }
                     }
                 }
-                textX += (5 * pixelSize) + 10;
+                textX += letterWidth + (pixelSize * 2);
             });
 
 
             // Window
-            const windowY = signY + signHeight + 10;
-            const windowHeight = 120;
+            const windowY = signY + signHeight + shopHeight * 0.03;
+            const windowHeight = shopHeight * 0.4;
+            const windowX = x + shopWidth * 0.03;
+            const windowWidth = shopWidth * 0.94;
             ctx.fillStyle = coffeeDarkBrown;
-            ctx.fillRect(x + 10, windowY, shopWidth - 20, windowHeight);
+            ctx.fillRect(windowX, windowY, windowWidth, windowHeight);
             ctx.fillStyle = coffeeWindow;
-            ctx.fillRect(x + 20, windowY + 10, shopWidth - 40, windowHeight - 20);
+            ctx.fillRect(windowX + shopWidth*0.03, windowY + shopHeight*0.03, windowWidth - shopWidth*0.06, windowHeight - shopHeight*0.06);
 
              // Window reflection
             ctx.strokeStyle = 'rgba(255,255,255,0.4)';
             ctx.lineWidth = 2;
             ctx.beginPath();
-            for(let i=0; i< (shopWidth - 40) / 10; i++){
-                ctx.moveTo(x + 20 + i * 15, windowY + 10);
-                ctx.lineTo(x + 20 + i * 15 + 30, windowY + 10 + 20);
+            const innerWindowX = windowX + shopWidth*0.03;
+            const innerWindowY = windowY + shopHeight*0.03;
+            for(let i=0; i< (windowWidth - shopWidth*0.06) / 10; i++){
+                ctx.moveTo(innerWindowX + i * 15, innerWindowY);
+                ctx.lineTo(innerWindowX + i * 15 + 30, innerWindowY + 20);
             }
             ctx.stroke();
 
 
             // Counter
-            const counterY = windowY + windowHeight + 10;
+            const counterY = windowY + windowHeight + shopHeight * 0.03;
+            const counterHeight = shopHeight * 0.04;
             ctx.fillStyle = coffeeMidBrown;
-            ctx.fillRect(x, counterY, shopWidth, 15);
+            ctx.fillRect(x, counterY, shopWidth, counterHeight);
             ctx.strokeStyle = coffeeDarkBrown;
-            ctx.strokeRect(x, counterY, shopWidth, 15);
+            ctx.strokeRect(x, counterY, shopWidth, counterHeight);
 
             // Espresso Machine
+            const machineW = shopWidth * 0.2;
+            const machineH = shopHeight * 0.14;
+            const machineX = x + shopWidth * 0.13;
+            const machineY = windowY + windowHeight - machineH;
             ctx.fillStyle = '#9e9e9e';
-            ctx.fillRect(x + 40, windowY + 60, 60, 50);
+            ctx.fillRect(machineX, machineY, machineW, machineH);
             ctx.strokeStyle = '#424242';
-            ctx.strokeRect(x + 40, windowY + 60, 60, 50);
+            ctx.strokeRect(machineX, machineY, machineW, machineH);
             ctx.fillStyle = '#616161';
-            ctx.fillRect(x + 45, windowY + 70, 20, 10);
-            ctx.fillRect(x + 75, windowY + 70, 20, 10);
+            ctx.fillRect(machineX + machineW*0.1, machineY + machineH*0.2, machineW*0.3, machineH*0.2);
+            ctx.fillRect(machineX + machineW*0.6, machineY + machineH*0.2, machineW*0.3, machineH*0.2);
 
             // Stools
-            const stoolY = counterY + 15;
+            const stoolY = counterY + counterHeight;
+            const stoolW = shopWidth * 0.1;
+            const stoolH = shopHeight * 0.06;
+            const legH = shopHeight * 0.04;
+            const legW = shopWidth * 0.015;
+
+            const stoolX1 = x + shopWidth * 0.5;
             ctx.fillStyle = coffeeMidBrown;
-            ctx.fillRect(x + 150, stoolY, 30, 20); // Seat
-            ctx.fillRect(x + 155, stoolY + 20, 5, 15); // Leg 1
-            ctx.fillRect(x + 170, stoolY + 20, 5, 15); // Leg 2
+            ctx.fillRect(stoolX1, stoolY, stoolW, stoolH); // Seat
+            ctx.fillRect(stoolX1 + stoolW*0.15, stoolY + stoolH, legW, legH); // Leg 1
+            ctx.fillRect(stoolX1 + stoolW*0.7, stoolY + stoolH, legW, legH); // Leg 2
 
-            ctx.fillRect(x + 200, stoolY, 30, 20); // Seat
-            ctx.fillRect(x + 205, stoolY + 20, 5, 15); // Leg 1
-            ctx.fillRect(x + 220, stoolY + 20, 5, 15); // Leg 2
+            const stoolX2 = x + shopWidth * 0.67;
+            ctx.fillRect(stoolX2, stoolY, stoolW, stoolH); // Seat
+            ctx.fillRect(stoolX2 + stoolW*0.15, stoolY + stoolH, legW, legH); // Leg 1
+            ctx.fillRect(stoolX2 + stoolW*0.7, stoolY + stoolH, legW, legH); // Leg 2
 
-            ctx.fillRect(x + 250, stoolY, 30, 20); // Seat
-            ctx.fillRect(x + 255, stoolY + 20, 5, 15); // Leg 1
-            ctx.fillRect(x + 270, stoolY + 20, 5, 15); // Leg 2
+            const stoolX3 = x + shopWidth * 0.84;
+            ctx.fillRect(stoolX3, stoolY, stoolW, stoolH); // Seat
+            ctx.fillRect(stoolX3 + stoolW*0.15, stoolY + stoolH, legW, legH); // Leg 1
+            ctx.fillRect(stoolX3 + stoolW*0.7, stoolY + stoolH, legW, legH); // Leg 2
         }
 
         function drawManagersOffice() {
@@ -1364,6 +1357,10 @@
             ctx.fillStyle = '#a1887f';
             ctx.fillRect(0, 0, worldWidth, desk.y + desk.height);
             storageCells.forEach((cell, index) => {
+                // Do not draw the storage cells that are being replaced by the coffee shop
+                if (index === 2 || index === 5) {
+                    return;
+                }
                 if (!unlocks.storage[index]) {
                     const r = cell.rect;
                     ctx.fillStyle = 'rgba(0,0,0,0.5)';
@@ -1438,11 +1435,18 @@
             drawLoadingDock();
             drawManagersOffice();
 
-            // Draw Coffee Shop
-            const lastShelf = shelves[5];
-            const coffeeShopX = lastShelf.rect.x + lastShelf.rect.w + 40;
-            const coffeeShopY = desk.y + desk.height; // Align bottom of shop wall with bottom of main wall
-            drawCoffeeShop(coffeeShopX, coffeeShopY);
+            // Draw Coffee Shop in place of the rightmost storage cells
+            if (storageCells.length > 5) {
+                const topRightCell = storageCells[5];
+                const bottomRightCell = storageCells[2];
+
+                const coffeeShopX = topRightCell.rect.x;
+                const coffeeShopY = topRightCell.rect.y;
+                const coffeeShopWidth = topRightCell.rect.w;
+                const coffeeShopHeight = (bottomRightCell.rect.y + bottomRightCell.rect.h) - topRightCell.rect.y;
+
+                drawCoffeeShop(coffeeShopX, coffeeShopY, coffeeShopWidth, coffeeShopHeight);
+            }
         }
 
         function drawStaticUI() {


### PR DESCRIPTION
This commit introduces a non-functional, purely visual coffee shop to the main store area, replacing the rightmost storage cells.

- A `drawCoffeeShop` JavaScript function has been created to render the coffee shop using the HTML5 Canvas API. The visual style is consistent with the existing pixel-art aesthetic of the game.
- The function is called within the `drawStoreBackground` rendering loop.
- Logic has been added to prevent the replaced storage cells from being drawn.
- The coffee shop is dynamically positioned and sized to perfectly occupy the space of the replaced cells, ensuring it integrates seamlessly with the store layout as an adjacent room.