### PR TITLE
This commit adjusts the trigger zone for the coffee shop fund generat…

### DIFF
--- a/index.html
+++ b/index.html
@@ -1462,7 +1462,7 @@
                     x: coffeeShop.rect.x,
                     y: coffeeShop.rect.y,
                     w: coffeeShop.rect.w,
-                    h: coffeeShop.rect.h * 0.55 // Top 55% of the coffee shop sprite
+                    h: coffeeShop.rect.h * 0.75 // Area behind the counter
                 };
 
                 // Define the collision line for the counter


### PR DESCRIPTION
…ion.

The previous implementation had the trigger zone positioned too high, at the level of the signage. This change lowers the zone to the accessible counter area, ensuring the player can correctly trigger the fund-earning mechanic.

- The height of the `coffeeShop.behindCounterZone` has been increased to cover the area behind the counter.