### PR TITLE
Fix barista unlock issue

### DIFF
--- a/index.html
+++ b/index.html
@@ -4377,7 +4377,7 @@
 
             if (type === 'employee') {
                 cost = unlockCosts.employees[key];
-                if (key === 'barista' && !unlocks.venues.coffeeShop) {
+                if (key === 'barista' && !unlocks.coffeeShop) {
                     prerequisite = false;
                     prerequisiteMessage = "You must unlock the Coffee Shop first!";
                 }


### PR DESCRIPTION
This commit fixes a bug that prevented the barista from being unlocked. The `purchaseUnlock` function was checking for `unlocks.venues.coffeeShop` instead of `unlocks.coffeeShop`, which caused a JavaScript error. This has been corrected.