### PR TITLE
Refactor coffee shop drawing and remove background

### DIFF
--- a/index.html
+++ b/index.html
@@ -4424,7 +4424,8 @@
                 const cost = developerMode ? 0 : unlockCosts.shelves[i];
                 const isUnlocked = unlocks.shelves[i];
                 const canAfford = shopPoints >= cost;
-                const prerequisiteMet = unlocks.shelves[i - 1];
+                // The coffee shop (index 5) has no prerequisite.
+                const prerequisiteMet = i === 5 ? true : unlocks.shelves[i - 1];
                 const div = document.createElement('div');
                 div.className = 'flex items-center justify-between p-2 bg-white/50 rounded-md';
                 const shelfName = i === 5 ? "Coffee Shop" : `Shelf ${i + 1}`;


### PR DESCRIPTION
Refactors the coffee shop drawing logic to be more modular. The monolithic `drawCoffeeShopBackground` and `drawCoffeeShopForeground` functions have been broken down into smaller, self-contained functions for each element (sign, window, counter, etc.).

This change also removes the main rectangular background of the coffee shop and the diagonal reflection lines on the window, allowing the key elements to blend more seamlessly into the game's background, as requested by the user.

The game's main render loop has been updated to draw these components as individual dynamic entities, ensuring correct z-ordering with other game objects.

This commit also fixes several follow-up bugs:
- A crash caused by a dangling reference to a deleted 'loader' object.
- The coffee shop appearing before being unlocked.
- The barista not appearing when the coffee shop is unlocked.
- The unlocks panel is updated to correctly label the 'Coffee Shop' unlock.
- The coffee shop unlock prerequisite is removed, allowing it to be purchased independently.