### PR TITLE
fix: Correct coffee shop rendering condition

### DIFF
--- a/index.html
+++ b/index.html
@@ -3172,7 +3172,7 @@
             drawStoreBackground();
             const dynamicEntities = [...customers, { y: cashierCounter.y + cashierCounter.h, type: 'cashier-counter' }, ...shelves, player, stocker, cashier, barista, manager, salesperson];
 
-            if (unlocks.shelves[5]) {
+            if (unlocks.facilities.coffeeShop) {
                 const { x, y, w: shopWidth, h: shopHeight } = coffeeShop.rect;
 
                 const signYPos = y + shopHeight * 0.1;


### PR DESCRIPTION
After decoupling the coffee shop from the shelf unlocks, a regression was introduced where the coffee shop would not render upon being unlocked. This was because the drawing logic in the `gameLoop` was still conditional on `unlocks.shelves[5]` instead of the new `unlocks.facilities.coffeeShop`.

This commit corrects the condition in the `gameLoop` to ensure the coffee shop is drawn when the corresponding facility is unlocked.