### PR TITLE
Feat: Adjust cashier counter position

### DIFF
--- a/index.html
+++ b/index.html
@@ -3519,8 +3519,8 @@
             }
 
 
-            cashierCounter.x = storeShiftX + 40;
-            cashierCounter.y = (desk.y - cashierCounter.h) + 40;
+            cashierCounter.x = storeShiftX + 80;
+            cashierCounter.y = (desk.y - cashierCounter.h) + 140;
 
             managersOffice.w = officeWidth;
             managersOffice.h = canvas.height / 2;


### PR DESCRIPTION
Moves the cashier counter 40 pixels to the right and 100 pixels down as requested by the user.

The changes were made in the `initializeLayout` function in `index.html`.
- `cashierCounter.x` was changed from `storeShiftX + 40` to `storeShiftX + 80`.
- `cashierCounter.y` was changed from `(desk.y - cashierCounter.h) + 40` to `(desk.y - cashierCounter.h) + 140`.