### PR TITLE
Feat: Add Sales and Specials Shelves with Fixes

### DIFF
--- a/index.html
+++ b/index.html
@@ -5336,7 +5336,7 @@ function openProductAssignmentForShelf(shelf, slotIndex) {
                 let content = '';
 
                 if (slot.assignedItem) {
-                    const canPlaceMore = player.basket.includes(slot.assignedItem) && slot.quantity < MAX_SHELF_STACK;
+                    const canPlaceMore = player.basket.some(item => item.itemName === slot.assignedItem) && slot.quantity < MAX_SHELF_STACK;
                     const canTake = slot.quantity > 0 && player.basket.length < MAX_BASKET_SIZE;
                     content = `
                         <div>
@@ -5639,6 +5639,12 @@ function openProductAssignmentForShelf(shelf, slotIndex) {
                     unlocks = gameState.unlocks || unlocks;
                     if (!unlocks.facilities) {
                         unlocks.facilities = { coffeeShop: false };
+                    }
+                    // PATCH: Ensure unlocks.shelves is the correct length for saved games
+                    if (unlocks.shelves.length < 8) {
+                        for (let i = unlocks.shelves.length; i < 8; i++) {
+                            unlocks.shelves.push(false);
+                        }
                     }
                     loadingDockPackages = gameState.loadingDockPackages || [];
                     customerDemand = gameState.customerDemand || {};


### PR DESCRIPTION
This commit introduces two new shelf types, 'SALES' and 'SPECIALS', and includes fixes for issues identified during implementation.

- **New Shelf Types:**
  - Added 2 new shelves ('SALES' and 'SPECIALS'), bringing the total to 8.
  - 'SALES' shelf: Red tint, 15% discount, attracts wandering customers, and has a chance to trigger an impulse buy.
  - 'SPECIALS' shelf: Blue tint, 25% price increase, removes the cheapest item from the customer's original shopping list.

- **Systemic Changes:**
  - Refactored the core basket/order data structure from a string array to an array of objects (`{itemName, shelfType}`) to track item origins. This change was applied globally to all player, customer, and employee logic.
  - Updated the Unlocks panel to display the new shelves with their correct names and costs (30 points).

- **Bug Fixes:**
  - Corrected the shelf initialization and save game loading logic to ensure all 8 shelves render correctly, even when loading from an older save file.
  - Removed the unlock prerequisite for 'SALES' and 'SPECIALS' shelves, allowing them to be purchased independently.
  - Fixed a rendering bug where the unique tints and names for the new shelves were not displayed when they were in a locked state.
  - Fixed a bug that prevented stocking more than one item on a newly assigned shelf.