### PR TITLE
Feat: Add Sales and Specials Shelves with Final Fixes

### DIFF
--- a/index.html
+++ b/index.html
@@ -4809,8 +4809,10 @@
             } else if (type === 'shelf') {
                 key = parseInt(key);
                 cost = unlockCosts.shelves[key];
-                if (key > 0 && !unlocks.shelves[key - 1]) {
-                    prerequisite = false;
+                if (key < 6) { // Prerequisite only for normal shelves
+                    if (key > 0 && !unlocks.shelves[key - 1]) {
+                        prerequisite = false;
+                    }
                 }
             } else if (type === 'facility') {
                 cost = unlockCosts.facilities[key];


### PR DESCRIPTION
This commit introduces two new shelf types, 'SALES' and 'SPECIALS', and includes all fixes for issues identified during implementation.

- **New Shelf Types:**
  - Added 2 new shelves ('SALES' and 'SPECIALS'), bringing the total to 8.
  - 'SALES' shelf: Red tint, 15% discount, attracts wandering customers, and has a chance to trigger an impulse buy.
  - 'SPECIALS' shelf: Blue tint, 25% price increase, removes the cheapest item from the customer's original shopping list.

- **Systemic Changes:**
  - Refactored the core basket/order data structure from a string array to an array of objects (`{itemName, shelfType}`) to track item origins. This change was applied globally to all player, customer, and employee logic.
  - Updated the Unlocks panel to display the new shelves with their correct names and costs (30 points).

- **Bug Fixes:**
  - Corrected the shelf initialization and save game loading logic to ensure all 8 shelves render correctly, even when loading from an older save file.
  - Fixed a rendering bug where the unique tints and names for the new shelves were not displayed when they were in a locked state.
  - Fixed a bug that prevented stocking more than one item on a newly assigned shelf.
  - Corrected the purchase logic to remove the unlock prerequisite for 'SALES' and 'SPECIALS' shelves, allowing them to be purchased independently at any time.