### PR TITLE
Fix: Correct 'Start Game' and 'New Game' screen logic

### DIFF
--- a/index.html
+++ b/index.html
@@ -5522,6 +5522,8 @@ function openProductAssignmentForShelf(shelf, slotIndex) {
             hideScreen('new-game-screen');
             hideScreen('dev-mode-screen');
             hideScreen('family-store-screen');
+            hideScreen('specialty-store-screen');
+            hideScreen('casual-mode-screen');
 
             // 2. Reset everything
             localStorage.removeItem('artEmporiumSave');
@@ -5749,7 +5751,7 @@ function openProductAssignmentForShelf(shelf, slotIndex) {
                 if (localStorage.getItem('artEmporiumSave')) {
                     hideScreen('new-game-screen');
                 } else {
-                    showMessage("You must select a game mode to continue.");
+                    startGame(); // Start a default game if no save exists
                 }
             });
 


### PR DESCRIPTION
This commit addresses two issues related to the new game flow:

1.  The 'Start Game' buttons on the 'Casual' and 'Specialty Store' option screens now correctly start the game. The `startGame` function has been updated to hide these screens upon initiation.

2.  The behavior of the 'New Game' screen has been adjusted. The close button no longer requires a selection. If no save data is present, closing the screen now defaults to a 'Standard Unlocks' game, as requested.