### PR TITLE
feat: Make "Your basket is full" message temporary

### DIFF
--- a/index.html
+++ b/index.html
@@ -4587,7 +4587,7 @@
 
         function takeItemFromPackage(packageIndex) {
             if (player.basket.length >= MAX_BASKET_SIZE) {
-                showMessage("Your basket is full!");
+                spawnFloatingText("Your basket is full!", player.x, player.y - 90, '#ef4444');
                 return;
             }
             const pkg = loadingDockPackages[packageIndex];
@@ -5401,7 +5401,7 @@ function openProductAssignmentForShelf(shelf, slotIndex) {
                     openStorageCell(cell); // Refresh panel
                 }
             } else {
-                showMessage("Your basket is full!");
+                spawnFloatingText("Your basket is full!", player.x, player.y - 90, '#ef4444');
             }
         }
 


### PR DESCRIPTION
The "Your basket is full!" message was previously a blocking pop-up that required user interaction to dismiss.

This commit replaces the `showMessage` call with the existing `spawnFloatingText` function. This makes the notification a temporary, non-blocking message that fades out on its own, improving the flow of the game.