### PR TITLE
Feat: Add glowing indicators for customer assistance

### DIFF
--- a/index.html
+++ b/index.html
@@ -1086,6 +1086,31 @@
                     wrapText(ctx, this.request, this.x, bubbleY + 20, bubbleWidth - 20, 20);
                 }
 
+                // Assistance indicators
+                const indicatorY = this.y - this.frameHeight - 25;
+                if (this.behaviorType === 'needsInteraction' && !this.isInteractedWith) {
+                    ctx.font = 'bold 36px "Indie Flower", cursive';
+                    ctx.textAlign = 'center';
+                    ctx.shadowColor = 'rgba(0, 150, 255, 0.9)';
+                    ctx.shadowBlur = 15;
+                    ctx.fillStyle = 'rgba(0, 150, 255, 0.5)';
+                    ctx.fillText('?', this.x, indicatorY);
+                    ctx.shadowBlur = 0; // Reset shadow
+                    ctx.fillStyle = '#fff';
+                    ctx.fillText('?', this.x, indicatorY);
+                } else if (this.behaviorType === 'needsAssistance' && !this.needsAssistanceFulfilled) {
+                    ctx.font = 'bold 36px "Indie Flower", cursive';
+                    ctx.textAlign = 'center';
+                    ctx.shadowColor = 'rgba(0, 255, 100, 0.9)';
+                    ctx.shadowBlur = 15;
+                    ctx.fillStyle = 'rgba(0, 255, 100, 0.5)';
+                    ctx.fillText('!', this.x, indicatorY);
+                    ctx.shadowBlur = 0; // Reset shadow
+                    ctx.fillStyle = '#fff';
+                    ctx.fillText('!', this.x, indicatorY);
+                }
+
+
                 ctx.font = '20px "Indie Flower", cursive';
                 ctx.textAlign = 'center';
                 const displayName = this.name;


### PR DESCRIPTION
This commit introduces visual indicators for customers requiring assistance.

- A glowing blue '?' is now displayed above customers who have the 'needsInteraction' behavior type.
- A glowing green '!' is displayed above customers with the 'needsAssistance' behavior type.

These indicators are rendered directly on the canvas within the `Customer.draw()` method and are conditionally displayed based on the customer's state, disappearing after the player has provided the required assistance. This provides clear, at-a-glance information to the player about customer needs.