### PR TITLE
Fix: Unlock Drawing Storage Cell by default

### DIFF
--- a/index.html
+++ b/index.html
@@ -821,7 +821,7 @@
             employees: { cashier: false, stocker: false, barista: false, manager: false, salesperson: false },
             shelves: [true, false, false, false, false, false],
             facilities: { coffeeShop: false },
-            storage: [false, false, false, false, false, false]
+            storage: [true, false, false, false, false, false]
         };
 
         const unlockCosts = {
@@ -5680,7 +5680,7 @@ function openProductAssignmentForShelf(shelf, slotIndex) {
                 employees: { cashier: false, stocker: false, barista: false, manager: false, salesperson: false },
                 shelves: [true, false, false, false, false, false],
                 facilities: { coffeeShop: false },
-                storage: [false, false, false, false, false, false]
+                storage: [true, false, false, false, false, false]
             };
 
             Object.keys(items).forEach(item => inventory[item] = 5);


### PR DESCRIPTION
The 'Drawing Storage Cell' was not unlocked by default. This created a gameplay dependency issue where players could not assign items to shelves, which in turn prevented customers from spawning, making the game unplayable at the start.

This change modifies the initial game state in two places to set the first storage cell to unlocked by default for all new game instances. This ensures the core gameplay loop can be initiated without issues.