### PR TITLE
Refactor coffee shop storage to a single cell

### DIFF
--- a/index.html
+++ b/index.html
@@ -805,7 +805,7 @@
             rect: { x: 0, y: 0, w: 0, h: 0 },
             y: 0,
             behindCounterZone: { x: 0, y: 0, w: 0, h: 0 },
-            storage: [] // New storage for coffee items
+            storage: null // A single storage object for all coffee items
         };
         const managersOffice = { x: 0, y: 0, w: 100, h: 100 };
         const officeComputer = { x: 0, y: 0, w: 0, h: 0 };
@@ -1750,34 +1750,55 @@
         function drawCoffeeStorage() {
             if (!unlocks.facilities.coffeeShop || !coffeeShop.storage) return;
 
-            coffeeShop.storage.forEach(cell => {
-                const r = cell.rect;
-                ctx.fillStyle = '#a1887f'; // A brown color matching the office
-                ctx.fillRect(r.x, r.y, r.w, r.h);
-                ctx.strokeStyle = '#4e342e';
-                ctx.lineWidth = 2;
-                ctx.strokeRect(r.x, r.y, r.w, r.h);
+            const cell = coffeeShop.storage;
+            const r = cell.rect;
+            const perspective = 0.25;
+            const insetX = r.w * perspective;
+            const insetY = r.h * perspective;
 
-                // Capacity Bar
-                const quantity = cell.items[cell.label] || 0;
-                const fillPercent = Math.min(1, quantity / cell.capacity);
-                const barY = r.y + r.h - 12;
-                ctx.fillStyle = '#eeeeee';
-                ctx.fillRect(r.x + 4, barY, r.w - 8, 8);
-                ctx.fillStyle = '#76ff03';
-                ctx.fillRect(r.x + 4, barY, (r.w - 8) * fillPercent, 8);
-                ctx.strokeStyle = '#5d4037';
-                ctx.strokeRect(r.x + 4, barY, r.w - 8, 8);
+            const backWall = {
+                x: r.x + insetX,
+                y: r.y + insetY,
+                w: r.w - insetX * 2,
+                h: r.h - insetY * 2
+            };
 
+            ctx.fillStyle = '#d7ccc8'; // Light gray-brown, same as main storage
+            ctx.fillRect(r.x, r.y, r.w, r.h);
 
-                // Simple label
-                ctx.fillStyle = '#f7e7d8';
-                ctx.font = '12px "Patrick Hand"';
-                ctx.textAlign = 'center';
-                ctx.textBaseline = 'middle';
-                ctx.fillText(`${cell.label.substring(0,5)}`, r.x + r.w / 2, r.y + (r.h / 2) - 8);
-                ctx.fillText(`(${quantity})`, r.x + r.w / 2, r.y + (r.h / 2) + 8);
-            });
+            ctx.fillStyle = '#bcaaa4'; // Darker back wall
+            ctx.fillRect(backWall.x, backWall.y, backWall.w, backWall.h);
+
+            ctx.strokeStyle = '#5d4037';
+            ctx.lineWidth = 3;
+
+            // Perspective lines
+            ctx.beginPath();
+            ctx.moveTo(r.x, r.y); ctx.lineTo(backWall.x, backWall.y);
+            ctx.moveTo(r.x + r.w, r.y); ctx.lineTo(backWall.x + backWall.w, backWall.y);
+            ctx.moveTo(r.x, r.y + r.h); ctx.lineTo(backWall.x, backWall.y + backWall.h);
+            ctx.moveTo(r.x + r.w, r.y + r.h); ctx.lineTo(backWall.x + backWall.w, backWall.y + backWall.h);
+            ctx.stroke();
+
+            // Outlines
+            ctx.strokeRect(r.x, r.y, r.w, r.h);
+            ctx.strokeRect(backWall.x, backWall.y, backWall.w, backWall.h);
+
+            // Capacity Bar
+            const currentFill = Object.values(cell.items).reduce((a, b) => a + b, 0);
+            const fillPercent = Math.min(1, currentFill / cell.capacity);
+            ctx.fillStyle = '#eeeeee';
+            ctx.fillRect(backWall.x + 5, backWall.y + backWall.h - 15, backWall.w - 10, 10);
+            ctx.fillStyle = '#76ff03';
+            ctx.fillRect(backWall.x + 5, backWall.y + backWall.h - 15, (backWall.w - 10) * fillPercent, 10);
+            ctx.strokeStyle = '#5d4037';
+            ctx.strokeRect(backWall.x + 5, backWall.y + backWall.h - 15, backWall.w - 10, 10);
+
+            // Label
+            ctx.fillStyle = '#5d4037';
+            ctx.font = '18px "Indie Flower", cursive';
+            ctx.textAlign = 'center';
+            ctx.fillText(cell.label, cell.rect.x + cell.rect.w / 2, cell.rect.y + cell.rect.h + 20);
         }
 
         function drawStaticUI() {
@@ -2569,35 +2590,48 @@
                     }
                     break;
                 case 'stocking_coffee':
-                     if (!barista.task) {
-                        if (barista.basket.length === 0) {
+                    if (!barista.task) {
+                        // If basket is empty or storage doesn't exist, go idle.
+                        if (barista.basket.length === 0 || !coffeeShop.storage) {
                             barista.state = 'idle';
                             break;
                         }
-                        const itemToStock = barista.basket[0];
-                        const targetCell = coffeeShop.storage.find(c => c.label === itemToStock);
-                        if (targetCell) {
-                            barista.task = {
-                                item: itemToStock,
-                                target: { x: targetCell.rect.x + targetCell.rect.w / 2, y: targetCell.rect.y + targetCell.rect.h + 10 }
-                            };
-                        } else {
-                            barista.basket.shift();
-                        }
+                        // Set the task to go to the single coffee storage location.
+                        const storageCell = coffeeShop.storage;
+                        barista.task = {
+                            target: {
+                                x: storageCell.rect.x + storageCell.rect.w / 2,
+                                y: storageCell.rect.y + storageCell.rect.h + 10
+                            }
+                        };
                     }
-                    if (barista.task && moveCharacterTowards(barista, barista.task.target.x, barista.task.target.y, deltaTime)) {
-                        const itemToStock = barista.task.item;
-                        const cell = coffeeShop.storage.find(c => c.label === itemToStock);
-                        const itemIndexInBasket = barista.basket.indexOf(itemToStock);
 
-                        if (cell && itemIndexInBasket > -1) {
-                            const currentFill = cell.items[itemToStock] || 0;
-                            if (currentFill < cell.capacity) {
-                                 cell.items[itemToStock]++;
-                                 barista.basket.splice(itemIndexInBasket, 1);
+                    // Move towards the storage location.
+                    if (barista.task && moveCharacterTowards(barista, barista.task.target.x, barista.task.target.y, deltaTime)) {
+                        const storageCell = coffeeShop.storage;
+                        const newBasket = [];
+                        let itemsStocked = 0;
+
+                        // Iterate through the basket and try to stock each item.
+                        for (const itemToStock of barista.basket) {
+                            const currentFill = Object.values(storageCell.items).reduce((a, b) => a + b, 0);
+                            // Check if it's a valid coffee item AND there's space.
+                            if (storageCell.allowedItems.includes(itemToStock) && currentFill < storageCell.capacity) {
+                                storageCell.items[itemToStock] = (storageCell.items[itemToStock] || 0) + 1;
+                                itemsStocked++;
+                            } else {
+                                // If it can't be stocked, put it back in the "new" basket.
+                                newBasket.push(itemToStock);
                             }
                         }
+
+                        if (itemsStocked > 0) {
+                            spawnFloatingText(`Stashed ${itemsStocked} coffee items.`, barista.x, barista.y - 90, '#654321');
+                        }
+
+                        barista.basket = newBasket; // Update basket with any remaining items.
                         barista.task = null;
+                        barista.state = 'idle'; // Go idle after finishing the stocking attempt.
                     }
                     break;
             }
@@ -3130,16 +3164,6 @@
                 }
             }
 
-            const clickedCoffeeCell = coffeeShop.storage.find(c => worldX >= c.rect.x && worldX <= c.rect.x + c.rect.w && worldY >= c.rect.y && worldY <= c.rect.y + c.rect.h);
-            if (clickedCoffeeCell) {
-                if (Math.hypot(player.x - (clickedCoffeeCell.rect.x + clickedCoffeeCell.rect.w/2), player.y - (clickedCoffeeCell.rect.y + clickedCoffeeCell.rect.h)) < 150) {
-                    openClipboardPanel();
-                    openCoffeeStoragePanel(clickedCoffeeCell);
-                    return;
-                }
-            }
-
-
             const neededItems = [...assignedNeeded, ...unassignedAvailable];
 
             if (neededItems.length > 0) {
@@ -3179,77 +3203,29 @@
         }
 
         function findCoffeeRestockingTask() {
-            const coffeeItems = ['Beans', 'Milks', 'Sugar', 'Snacks'];
+            if (!unlocks.facilities.coffeeShop || !coffeeShop.storage) return null;
+
+            const coffeeItems = coffeeShop.storage.allowedItems;
+            const currentStock = Object.values(coffeeShop.storage.items).reduce((a, b) => a + b, 0);
+
+            if (currentStock >= coffeeShop.storage.capacity) {
+                return null; // Storage is full.
+            }
+
             for (let i = 0; i < loadingDockPackages.length; i++) {
                 const pkg = loadingDockPackages[i];
+                // If there's a coffee package and the storage is not full, create a task.
                 if (coffeeItems.includes(pkg.itemName)) {
-                    const targetCell = coffeeShop.storage.find(c => c.label === pkg.itemName);
-                    if (targetCell) {
-                        const currentStock = targetCell.items[pkg.itemName] || 0;
-                        if (currentStock < targetCell.capacity) {
-                            const packageX = loadingDock.x + 10 + i * (PACKAGE_WIDTH + 10) + PACKAGE_WIDTH / 2;
-                            return {
-                                action: 'fetching_coffee',
-                                item: pkg.itemName,
-                                packageIndex: i,
-                                target: { x: packageX, y: loadingDock.y - 40 }
-                            };
-                        }
-                    }
+                    const packageX = loadingDock.x + 10 + i * (PACKAGE_WIDTH + 10) + PACKAGE_WIDTH / 2;
+                    return {
+                        action: 'fetching_coffee',
+                        item: pkg.itemName,
+                        packageIndex: i,
+                        target: { x: packageX, y: loadingDock.y - 40 }
+                    };
                 }
             }
             return null;
-        }
-
-        function openCoffeeStoragePanel(cell) {
-            activeStorageCell = cell; // Use the same global for simplicity
-            const storageGrid = document.getElementById('storage-grid');
-            document.getElementById('storage-title').textContent = `Manage ${cell.label}`;
-            storageGrid.innerHTML = '';
-
-            const stockAllButtonContainer = document.createElement('div');
-            stockAllButtonContainer.className = 'p-2 col-span-2';
-            const stockAllButton = document.createElement('button');
-            stockAllButton.className = 'btn-style w-full py-2';
-            stockAllButton.textContent = `Stock All ${cell.label} from Basket`;
-            stockAllButton.onclick = () => stockAllCoffeeFromBasket(cell);
-            stockAllButton.disabled = !player.basket.includes(cell.label);
-            stockAllButtonContainer.appendChild(stockAllButton);
-            storageGrid.appendChild(stockAllButtonContainer);
-
-            showAppScreen('storage-panel');
-        }
-
-        function stockAllCoffeeFromBasket(cell) {
-            const itemsToMove = player.basket.filter(item => item === cell.label);
-            if (itemsToMove.length === 0) return;
-
-            const currentFill = cell.items[cell.label] || 0;
-            const capacity = cell.capacity;
-            const availableSpace = capacity - currentFill;
-
-            if (itemsToMove.length > availableSpace) {
-                showMessage(`Not enough space in ${cell.label} storage. Needs space for ${itemsToMove.length} items, but only has ${availableSpace}.`);
-                return;
-            }
-
-            // Remove from basket and add to storage
-            const newBasket = [];
-            let movedCount = 0;
-            for(const item of player.basket) {
-                if(item === cell.label && movedCount < itemsToMove.length) {
-                    cell.items[cell.label]++;
-                    movedCount++;
-                } else {
-                    newBasket.push(item);
-                }
-            }
-
-            player.basket = newBasket;
-            updateBasketUI();
-            spawnFloatingText(`Stocked ${itemsToMove.length} ${cell.label}!`, player.x, player.y - 90, '#22c55e');
-            saveGame();
-            openCoffeeStoragePanel(cell); // Refresh the panel
         }
 
         function updatePlayer(deltaTime) {
@@ -4175,33 +4151,30 @@
                 const windowHeight = coffeeShop.rect.h * 0.4;
                 coffeeShop.collisionLineY = windowY + windowHeight + coffeeShop.rect.h * 0.03;
 
-                // Initialize coffee shop storage cells
-                const coffeeCellWidth = 40;
-                const coffeeCellHeight = 40;
-                const coffeeCellPadding = 10;
-                const coffeeStorageY = coffeeShop.rect.y - coffeeCellHeight - coffeeCellPadding;
-                const coffeeItems = ['Beans', 'Milks', 'Sugar', 'Snacks'];
-
-                if (coffeeShop.storage.length === 0) { // Only initialize if empty
-                    for (let i = 0; i < coffeeItems.length; i++) {
-                        coffeeShop.storage.push({
-                            label: coffeeItems[i],
-                            rect: {
-                                x: coffeeShop.rect.x + i * (coffeeCellWidth + coffeeCellPadding),
-                                y: coffeeStorageY,
-                                w: coffeeCellWidth,
-                                h: coffeeCellHeight
-                            },
-                            items: { [coffeeItems[i]]: 0 }, // Initialize with 0 of its own item
-                            capacity: 50
-                        });
-                    }
-                } else { // Just update positions and capacity on resize
-                     for (let i = 0; i < coffeeItems.length; i++) {
-                        coffeeShop.storage[i].rect.x = coffeeShop.rect.x + i * (coffeeCellWidth + coffeeCellPadding);
-                        coffeeShop.storage[i].rect.y = coffeeStorageY;
-                        coffeeShop.storage[i].capacity = 50; // Ensure capacity is set
-                    }
+                // Initialize the single coffee shop storage cell
+                if (!coffeeShop.storage) { // Only initialize if it doesn't exist
+                    const coffeeItems = ['Beans', 'Milks', 'Sugar', 'Snacks'];
+                    const storageWidth = coffeeShop.rect.w * 0.8; // Make it thinner than the shop
+                    const storageHeight = 60; // A fixed, thinner height
+                    coffeeShop.storage = {
+                        label: "Coffee Storage",
+                        rect: {
+                            x: coffeeShop.rect.x + (coffeeShop.rect.w - storageWidth) / 2, // Center it
+                            y: coffeeShop.rect.y - storageHeight - 20, // Position above the shop
+                            w: storageWidth,
+                            h: storageHeight
+                        },
+                        allowedItems: coffeeItems,
+                        items: coffeeItems.reduce((acc, item) => ({...acc, [item]: 0 }), {}),
+                        capacity: 200 // 50 for each of the 4 items
+                    };
+                } else { // Just update position on resize
+                    const storageWidth = coffeeShop.rect.w * 0.8;
+                    const storageHeight = 60;
+                    coffeeShop.storage.rect.w = storageWidth;
+                    coffeeShop.storage.rect.h = storageHeight;
+                    coffeeShop.storage.rect.x = coffeeShop.rect.x + (coffeeShop.rect.w - storageWidth) / 2;
+                    coffeeShop.storage.rect.y = coffeeShop.rect.y - storageHeight - 20;
                 }
             }
 
@@ -4423,6 +4396,19 @@
                          }
                      }
                  }
+            }
+
+            // Check for click on the single coffee storage cell
+            if (unlocks.facilities.coffeeShop && coffeeShop.storage) {
+                const cell = coffeeShop.storage;
+                const r = cell.rect;
+                if (worldX >= r.x && worldX <= r.x + r.w && worldY >= r.y && worldY <= r.y + r.h) {
+                    if (Math.hypot(player.x - (r.x + r.w / 2), player.y - (r.y + r.h)) < 150) {
+                        openClipboardPanel();
+                        openStorageCell(cell); // Use the generic storage panel
+                        return;
+                    }
+                }
             }
 
             const clickedCell = storageCells.find(c => worldX >= c.rect.x && worldX <= c.rect.x + c.rect.w && worldY >= c.rect.y && worldY <= c.rect.y + c.rect.h);


### PR DESCRIPTION
This commit refactors the coffee shop's four separate storage cells into a single, unified storage unit.

Key changes include:
- The `coffeeShop.storage` data structure is now a single object instead of an array.
- The `drawCoffeeStorage` function is updated to render a single, thinner cell with a style consistent with other main storage units.
- The Barista's AI (`updateBarista` and `findCoffeeRestockingTask`) is adapted to interact with the new single storage object for restocking.
- Player interaction is updated (`handleCanvasClick`) to use the generic `openStorageCell` UI for managing all coffee items from one panel.
- Obsolete functions related to the old storage system (`openCoffeeStoragePanel`, `stockAllCoffeeFromBasket`) have been removed.