### PR TITLE
fix: Remove ReferenceError in updateStocker

### DIFF
--- a/index.html
+++ b/index.html
@@ -2620,7 +2620,6 @@
                         }
                     }
 
-                    priceHistory = gameState.priceHistory || priceHistory;
                     break;
                 case 'fetching':
                     if (moveCharacterTowards(stocker, stocker.task.target.x, stocker.task.target.y, deltaTime)) {


### PR DESCRIPTION
Removes a line that was causing a `ReferenceError` due to the `gameState` variable being out of scope. This error halted script execution and prevented the game from rendering.