### PR TITLE
feat: Add market item deep dive view

### DIFF
--- a/index.html
+++ b/index.html
@@ -324,6 +324,45 @@
                             <!-- Individual item reports will be dynamically inserted here -->
                         </div>
                     </div>
+
+                    <!-- Market Item Deep Dive Panel -->
+                    <div id="market-item-deep-dive-panel" class="phone-app-screen hidden">
+                        <div class="flex justify-between items-center mb-2">
+                            <h2 id="market-deep-dive-title" class="text-3xl font-handwritten">Item Details</h2>
+                            <button id="market-deep-dive-back-btn" class="btn-style px-4 py-1">Back</button>
+                        </div>
+                        <div class="space-y-4">
+                            <!-- Detailed Graph -->
+                            <div class="w-full h-48 bg-white/50 rounded-md border-2 border-amber-800/20 p-1">
+                                <canvas id="market-deep-dive-canvas"></canvas>
+                            </div>
+                            <!-- Stats and Ordering -->
+                            <div class="grid grid-cols-2 gap-4">
+                                <div class="p-2 bg-white/50 rounded-md border border-amber-800/10">
+                                    <h3 class="font-handwritten text-lg border-b border-amber-800/20 mb-1">Stats</h3>
+                                    <div class="text-sm space-y-1">
+                                        <p>Base Cost: <span id="deep-dive-base-cost" class="font-bold">$--.--</span></p>
+                                        <p>7-Day High: <span id="deep-dive-high" class="font-bold text-red-500">$--.--</span></p>
+                                        <p>7-Day Low: <span id="deep-dive-low" class="font-bold text-green-500">$--.--</span></p>
+                                    </div>
+                                </div>
+                                <div class="p-2 bg-white/50 rounded-md border border-amber-800/10">
+                                    <h3 class="font-handwritten text-lg border-b border-amber-800/20 mb-1">Place Order</h3>
+                                    <div class="space-y-2">
+                                         <div class="flex items-center justify-between">
+                                            <span>Price:</span>
+                                            <span id="deep-dive-current-price" class="font-bold">$--.--</span>
+                                        </div>
+                                        <div class="flex items-center justify-between">
+                                            <label for="deep-dive-order-qty">Quantity:</label>
+                                            <input type="number" id="deep-dive-order-qty" min="1" value="1" class="w-20 p-1 text-center border-2 border-amber-800 rounded-md bg-white/80">
+                                        </div>
+                                        <button id="deep-dive-place-order-btn" data-item="" class="btn-style w-full py-1 mt-1">Order for $--.--</button>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
                     <!-- Items Panel -->
                     <div id="items-panel" class="phone-app-screen hidden">
                         <h2 class="text-3xl font-handwritten mb-4">Toggle Items</h2>
@@ -5817,6 +5856,192 @@ function showHint() {
             return percentChange;
         }
 
+        function openMarketItemDeepDivePanel(itemName) {
+            // 1. Switch view
+            showAppScreen('market-item-deep-dive-panel');
+
+            const itemData = priceHistory[itemName];
+            if (!itemData) {
+                console.error("No price history for item:", itemName);
+                return;
+            }
+
+            const history = itemData.history;
+            const baseCost = originalItemCosts[itemName];
+            const currentPrice = items[itemName].cost;
+
+            // 2. Populate panel with stats
+            document.getElementById('market-deep-dive-title').textContent = itemName;
+            document.getElementById('deep-dive-base-cost').textContent = `$${baseCost.toFixed(2)}`;
+            document.getElementById('deep-dive-high').textContent = `$${Math.max(...history).toFixed(2)}`;
+            document.getElementById('deep-dive-low').textContent = `$${Math.min(...history).toFixed(2)}`;
+            document.getElementById('deep-dive-current-price').textContent = `$${currentPrice.toFixed(2)}`;
+
+            // 3. Setup ordering controls
+            const qtyInput = document.getElementById('deep-dive-order-qty');
+            const orderBtn = document.getElementById('deep-dive-place-order-btn');
+
+            qtyInput.value = 1; // Reset to 1
+            orderBtn.dataset.item = itemName;
+
+            // Function to update the button text based on quantity
+            function updateOrderButtonText() {
+                const quantity = parseInt(qtyInput.value, 10) || 0;
+                const totalCost = (currentPrice * quantity);
+                orderBtn.textContent = `Order for $${totalCost.toFixed(2)}`;
+            }
+
+            qtyInput.oninput = updateOrderButtonText;
+            updateOrderButtonText(); // Set initial text
+
+            // Order button logic
+            orderBtn.onclick = () => {
+                const itemName = orderBtn.dataset.item;
+                const quantity = parseInt(qtyInput.value, 10);
+                const currentPrice = items[itemName].cost;
+                const totalCost = currentPrice * quantity;
+
+                if (isNaN(quantity) || quantity <= 0) {
+                    showMessage("Please enter a valid quantity.");
+                    return;
+                }
+
+                if (cash >= totalCost) {
+                    cash -= totalCost;
+                    dailyPlayerPurchases[itemName] = (dailyPlayerPurchases[itemName] || 0) + quantity;
+                    dailySupplyOrders.push({
+                        orderedBy: 'Player',
+                        itemName: itemName,
+                        quantity: quantity,
+                        cost: totalCost
+                    });
+
+                    let remainingQuantity = quantity;
+                    while (remainingQuantity > 0) {
+                        const quantityForPackage = Math.min(remainingQuantity, MAX_PACKAGE_SIZE);
+                        loadingDockPackages.push({ itemName: itemName, quantity: quantityForPackage });
+                        remainingQuantity -= quantityForPackage;
+                    }
+
+                    updateUI();
+                    saveGame();
+                    closeClipboard();
+                    showMessage(`Ordered ${quantity} ${itemName} for $${totalCost.toFixed(2)}!`);
+                } else {
+                    showMessage(`You can't afford this. You need $${totalCost.toFixed(2)}.`);
+                }
+            };
+
+            // Back button logic
+            document.getElementById('market-deep-dive-back-btn').onclick = () => {
+                // Find the category this item belongs to in order to go back to the correct detail screen
+                let itemCategoryKey = "Coffee Supplies"; // Default for coffee items
+                const foundCategory = storageCells.find(cell => cell.allowedItems.includes(itemName));
+                if (foundCategory) {
+                    itemCategoryKey = foundCategory.label;
+                }
+                openMarketDetailPanel(itemCategoryKey);
+            };
+
+            // 4. Call the detailed chart drawing function (to be fully implemented in the next step)
+            const canvas = document.getElementById('market-deep-dive-canvas');
+            drawDetailedMarketChart(canvas, itemName);
+        }
+
+        function drawDetailedMarketChart(canvas, itemName) {
+            if (!canvas || !canvas.parentElement) return;
+            canvas.width = canvas.parentElement.clientWidth;
+            canvas.height = canvas.parentElement.clientHeight;
+            const ctx = canvas.getContext('2d');
+            ctx.clearRect(0, 0, canvas.width, canvas.height);
+
+            const itemData = priceHistory[itemName];
+            if (!itemData || !itemData.history || itemData.history.length < 2) {
+                ctx.font = '16px "Patrick Hand"';
+                ctx.fillStyle = '#5d4037';
+                ctx.textAlign = 'center';
+                ctx.fillText("Not enough data for chart.", canvas.width / 2, canvas.height / 2);
+                return;
+            }
+
+            const history = itemData.history;
+            const predictions = itemData.predictions || [];
+            const fullData = [...history, ...predictions];
+
+            const maxVal = Math.max(...fullData);
+            const minVal = Math.min(...fullData);
+            const range = (maxVal - minVal === 0) ? 1 : (maxVal - minVal);
+
+            const padding = { top: 10, right: 10, bottom: 20, left: 30 };
+            const chartWidth = canvas.width - padding.left - padding.right;
+            const chartHeight = canvas.height - padding.top - padding.bottom;
+
+            // --- Draw Y-Axis Labels ---
+            ctx.font = '10px "VT323"';
+            ctx.fillStyle = '#5d4037';
+            ctx.textAlign = 'right';
+            ctx.textBaseline = 'middle';
+            ctx.fillText(`$${maxVal.toFixed(2)}`, padding.left - 4, padding.top);
+            ctx.fillText(`$${minVal.toFixed(2)}`, padding.left - 4, padding.top + chartHeight);
+
+            // --- Draw X-Axis Labels ---
+            const labels = [];
+            for (let i = 0; i < fullData.length; i++) {
+                const dayDiff = i - (history.length - 1);
+                if (dayDiff === 0) labels.push("Today");
+                else if (dayDiff > 0) labels.push(`+${dayDiff}d`);
+                else labels.push(`${dayDiff}d`);
+            }
+            ctx.textAlign = 'center';
+            ctx.textBaseline = 'top';
+            labels.forEach((label, index) => {
+                const x = padding.left + (index / (fullData.length - 1)) * chartWidth;
+                ctx.fillText(label, x, canvas.height - padding.bottom + 4);
+            });
+
+            // --- Draw Historical Data (Solid Line) ---
+            ctx.strokeStyle = '#5d4037';
+            ctx.lineWidth = 2;
+            ctx.beginPath();
+            history.forEach((point, index) => {
+                const x = padding.left + (index / (fullData.length - 1)) * chartWidth;
+                const y = padding.top + chartHeight - ((point - minVal) / range) * chartHeight;
+                if (index === 0) ctx.moveTo(x, y);
+                else ctx.lineTo(x, y);
+            });
+            ctx.stroke();
+
+             // --- Draw Predicted Data (Dashed Line) ---
+            if (predictions.length > 0) {
+                ctx.setLineDash([4, 4]);
+                ctx.strokeStyle = 'rgba(93, 64, 55, 0.6)';
+                ctx.beginPath();
+                // Start from the last historical point
+                const lastHistoryIndex = history.length - 1;
+                const startX = padding.left + (lastHistoryIndex / (fullData.length - 1)) * chartWidth;
+                const startY = padding.top + chartHeight - ((history[lastHistoryIndex] - minVal) / range) * chartHeight;
+                ctx.moveTo(startX, startY);
+                // Draw lines to each prediction
+                predictions.forEach((point, index) => {
+                    const x = padding.left + ((lastHistoryIndex + 1 + index) / (fullData.length - 1)) * chartWidth;
+                    const y = padding.top + chartHeight - ((point - minVal) / range) * chartHeight;
+                    ctx.lineTo(x, y);
+                });
+                ctx.stroke();
+                ctx.setLineDash([]); // Reset line dash
+            }
+
+            // --- Draw Data Points ---
+            fullData.forEach((point, index) => {
+                const x = padding.left + (index / (fullData.length - 1)) * chartWidth;
+                const y = padding.top + chartHeight - ((point - minVal) / range) * chartHeight;
+                ctx.fillStyle = (index < history.length) ? '#5d4037' : 'rgba(93, 64, 55, 0.6)';
+                ctx.beginPath();
+                ctx.arc(x, y, 3, 0, Math.PI * 2);
+                ctx.fill();
+            });
+        }
+
         function openMarketDetailPanel(categoryKey) {
             const detailPanel = document.getElementById('market-detail-panel');
             const mainPanel = document.getElementById('market-panel');
@@ -5840,7 +6065,8 @@ function showHint() {
 
             itemsToList.forEach((itemName, index) => {
                 const itemDiv = document.createElement('div');
-                itemDiv.className = 'p-2 bg-white/50 rounded-md border-2 border-amber-800/20 flex items-center space-x-4';
+                itemDiv.className = 'p-2 bg-white/50 rounded-md border-2 border-amber-800/20 flex items-center space-x-4 cursor-pointer hover:bg-amber-200/50 transition-colors';
+                itemDiv.addEventListener('click', () => openMarketItemDeepDivePanel(itemName));
 
                 const infoDiv = document.createElement('div');
                 infoDiv.className = 'flex-grow';


### PR DESCRIPTION
This commit introduces a new "deep dive" screen for individual items in the market application.

- Adds a new HTML panel (`market-item-deep-dive-panel`) for the detailed view.
- Implements the `openMarketItemDeepDivePanel` JavaScript function to populate the panel with item-specific stats and an order form.
- Creates a `drawDetailedMarketChart` function to render a more comprehensive price history and prediction graph.
- Adds a click listener to the market detail items to navigate to the new deep dive screen.
- Implements the ordering logic within the new panel.