### PR TITLE
fix: Correct companion mode connection logic

### DIFF
--- a/index.html
+++ b/index.html
@@ -8474,6 +8474,12 @@ function openProductAssignmentForShelf(shelf, slotIndex) {
             clipboard.addEventListener('click', (e) => {
                 const button = e.target.closest('button');
                 if (button && button.id) {
+                    // Check if the clicked button is inside the sync screen.
+                    // If it is, we let the event proceed normally for local connection.
+                    if (button.closest('#companion-sync-screen')) {
+                        return;
+                    }
+
                     e.stopPropagation(); // Prevent the event from bubbling further
                     e.preventDefault(); // Stop the default action
                     console.log(`Companion sending click for #${button.id}`);


### PR DESCRIPTION
This commit fixes a bug in the companion mode feature where the connection screen's controls were not functioning on the companion device.

The previous implementation had an event listener that was too aggressive, capturing all clicks within the phone UI and forwarding them to the host. This incorrectly included the "Connect" button, preventing the companion from initiating the connection locally.

The event listener in `setupCompanionActionListeners` has been refined to check if a clicked element is a descendant of the `#companion-sync-screen`. If it is, the event is allowed to proceed normally. Otherwise, the event is captured and sent to the host as intended. This ensures the connection UI is fully functional on the companion device while preserving the remote control functionality for the rest of the game's phone interface.