### PR TITLE
refactor(ui): Move phone Back and Close buttons to top

### DIFF
--- a/index.html
+++ b/index.html
@@ -231,6 +231,11 @@
 
                 <!-- The Paper -->
                 <div id="clipboard-paper" class="bg-amber-50 rounded-lg h-full flex flex-col overflow-hidden m-2 p-2 border-2 border-amber-900/20">
+                    <!-- Header Buttons -->
+                    <div class="flex-shrink-0 pb-4 flex justify-center items-center space-x-4">
+                        <button id="phone-back-btn" class="btn-style px-6 py-2">Back</button>
+                        <button id="close-phone" class="btn-style bg-red-700 hover:bg-red-600 px-6 py-2">Close</button>
+                    </div>
                     <!-- Companion Sync Screen (for Companion Device) -->
                     <div id="companion-sync-screen" class="phone-app-screen hidden h-full flex flex-col items-center justify-center text-center p-4">
                         <h2 class="text-3xl font-handwritten mb-4">Companion Sync</h2>
@@ -432,13 +437,6 @@
                     <span class="text-xl">Total: $<span id="restock-total">0.00</span></span>
                     <button id="place-order-btn" class="btn-style px-4 py-2">Place Order</button>
                 </div>
-
-
-                    <!-- Footer Buttons -->
-                    <div class="flex-shrink-0 pt-4 mt-auto flex justify-center items-center space-x-4">
-                        <button id="phone-back-btn" class="btn-style px-6 py-2">Back</button>
-                        <button id="close-phone" class="btn-style bg-red-700 hover:bg-red-600 px-6 py-2">Close</button>
-                    </div>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
Relocates the "Back" and "Close" buttons from the bottom of the phone's "paper" UI to the top. This change improves user experience by placing navigation controls in a more conventional and accessible location, without altering their functionality.