### PR TITLE
feat: Add 'Open in Tab' button for desktop users

### DIFF
--- a/index.html
+++ b/index.html
@@ -454,7 +454,10 @@
             <p class="mb-4 text-center">Scan this QR code with your companion device to sync.</p>
             <canvas id="qr-code-canvas" class="border-4 border-amber-800/50 rounded-lg"></canvas>
             <p id="host-status" class="mt-4 mb-6 text-sm text-center">Waiting for connection...</p>
-            <button id="host-sync-close-btn" class="btn-style px-6 py-2">Close</button>
+            <div class="flex space-x-4">
+                <button id="host-sync-close-btn" class="btn-style px-6 py-2">Close</button>
+                <a id="open-in-tab-btn" href="#" target="_blank" class="btn-style bg-blue-600 hover:bg-blue-500 px-6 py-2 hidden">Open in Tab</a>
+            </div>
         </div>
     </div>
 
@@ -8421,6 +8424,7 @@ function openProductAssignmentForShelf(shelf, slotIndex) {
 
             document.getElementById('host-sync-modal').classList.remove('hidden');
             document.getElementById('host-status').textContent = 'Generating connection...';
+            document.getElementById('open-in-tab-btn').classList.add('hidden'); // Hide button initially
 
             // Let PeerJS generate a unique ID for us.
             peer = new Peer();
@@ -8433,6 +8437,11 @@ function openProductAssignmentForShelf(shelf, slotIndex) {
                 try {
                     const baseUrl = window.location.origin + window.location.pathname;
                     const companionUrl = `${baseUrl}?companion_id=${id}`;
+
+                    // Set up the "Open in Tab" button
+                    const openInTabBtn = document.getElementById('open-in-tab-btn');
+                    openInTabBtn.href = companionUrl;
+                    openInTabBtn.classList.remove('hidden');
 
                     const qr = qrcode(0, 'L');
                     qr.addData(companionUrl);


### PR DESCRIPTION
This commit introduces an 'Open in Tab' button to the companion sync modal. This allows desktop users to easily open the companion app in a new browser tab without needing to scan a QR code.

The button is initially hidden and is only revealed after the PeerJS connection is established and a unique URL is generated. The button's `href` is dynamically set to this URL.

Changes:
- Added an `<a>` tag with the ID `open-in-tab-btn` to the `host-sync-modal` in `index.html`.
- Grouped the new button with the existing 'Close' button inside a `div` with `flex` layout.
- Modified the `initializeHost` JavaScript function to:
  - Hide the 'Open in Tab' button when the modal is first opened.
  - Set the `href` attribute of the button to the generated `companionUrl`.
  - Unhide the button once the URL is set.