### PR TITLE
feat: Invert companion app control flow

### DIFF
--- a/index.html
+++ b/index.html
@@ -169,6 +169,25 @@
         body.companion-mode #close-phone {
             display: none !important;
         }
+
+        /* Host Overlay for Companion Mode */
+        #host-clipboard-overlay {
+            position: absolute;
+            top: 0;
+            left: 0;
+            right: 0;
+            bottom: 0;
+            background-color: rgba(93, 64, 55, 0.7); /* semi-transparent brown */
+            z-index: 4000; /* Above the paper, below the clip */
+            /* display: flex; <-- REMOVED to fix specificity issue */
+            align-items: center;
+            justify-content: center;
+            text-align: center;
+            color: #f7e7d8;
+            padding: 2rem;
+            border-radius: 0.5rem; /* Match paper's rounded corners */
+            pointer-events: all; /* Make sure it captures clicks */
+        }
     </style>
 </head>
 <body class="p-4 flex flex-col items-center justify-center h-screen">
@@ -227,6 +246,11 @@
                 <div class="absolute top-0 left-1/2 -translate-x-1/2 -translate-y-1/2 w-40 h-20 bg-slate-400 border-4 border-slate-600 rounded-lg shadow-md">
                     <div class="w-full h-full bg-gradient-to-b from-slate-300 to-slate-500 rounded-md"></div>
                     <div class="absolute bottom-2 left-1/2 -translate-x-1/2 w-8 h-3 bg-slate-600 rounded-sm"></div>
+                </div>
+
+                <!-- Host Overlay -->
+                <div id="host-clipboard-overlay" class="hidden flex">
+                    <p class="text-2xl font-handwritten">The phone is being controlled by a companion device.</p>
                 </div>
 
                 <!-- The Paper -->
@@ -7613,6 +7637,11 @@ function openProductAssignmentForShelf(shelf, slotIndex) {
             isPhoneOpen = false;
             activePhoneScreen = null;
             closeNewspaperModal();
+
+            // STEP 2: Notify host of UI change
+            if (companionConnection && companionConnection.open) {
+                sendActionToHost({ type: 'ui_change', screen: 'closed' });
+            }
         }
 
         function showAppGrid() {
@@ -7621,6 +7650,11 @@ function openProductAssignmentForShelf(shelf, slotIndex) {
             activePhoneScreen = null;
             phoneScreenContext = {}; // Clear context when going home
             closeNewspaperModal();
+
+            // STEP 2: Notify host of UI change
+            if (companionConnection && companionConnection.open) {
+                sendActionToHost({ type: 'ui_change', screen: 'app-grid' });
+            }
         }
 
         function showAppScreen(panelId) {
@@ -7649,6 +7683,11 @@ function openProductAssignmentForShelf(shelf, slotIndex) {
                 orderFooter.classList.remove('hidden');
             } else {
                 orderFooter.classList.add('hidden');
+            }
+
+            // STEP 2: Notify host of UI change
+            if (companionConnection && companionConnection.open) {
+                sendActionToHost({ type: 'ui_change', screen: panelId, context: phoneScreenContext });
             }
         }
 
@@ -8506,6 +8545,9 @@ function openProductAssignmentForShelf(shelf, slotIndex) {
                 document.getElementById('host-status').textContent = '✅ Connected!';
                 document.getElementById('companion-sync-btn').classList.add('bg-green-500');
 
+                // STEP 4: Show the overlay on the host's clipboard
+                document.getElementById('host-clipboard-overlay').classList.remove('hidden');
+
                 // This map links button IDs from the companion to functions on the host.
                 // This is more reliable than simulating clicks.
                 const actionMap = new Map([
@@ -8529,6 +8571,27 @@ function openProductAssignmentForShelf(shelf, slotIndex) {
                 ]);
 
                 hostConnection.on('data', (data) => {
+                    // STEP 3: Handle UI mirroring messages from the companion
+                    if (data.type === 'ui_change') {
+                        console.log(`Host received UI change command:`, data);
+                        // The host's phone UI should now mirror the companion's actions.
+                        phoneScreenContext = data.context || {}; // Update context for complex screens
+                        switch (data.screen) {
+                            case 'closed':
+                                closeClipboard();
+                                break;
+                            case 'app-grid':
+                                openClipboardPanel(); // Ensure panel is open
+                                showAppGrid();
+                                break;
+                            default:
+                                openClipboardPanel(); // Ensure panel is open
+                                showAppScreen(data.screen);
+                                break;
+                        }
+                        return; // Don't need to send a full state update back for a UI-only change.
+                    }
+
                     if (data.action === 'click') {
                         const elementId = data.elementId;
                         console.log(`Host received click command for #${elementId}`);
@@ -8568,6 +8631,10 @@ function openProductAssignmentForShelf(shelf, slotIndex) {
                     document.getElementById('host-status').textContent = 'Companion disconnected.';
                     document.getElementById('companion-sync-btn').classList.remove('bg-green-500');
                     hostConnection = null;
+
+                    // STEP 4: Hide the overlay and close the clipboard for the host
+                    document.getElementById('host-clipboard-overlay').classList.add('hidden');
+                    closeClipboard();
                 });
             });
         }
@@ -8653,11 +8720,11 @@ function openProductAssignmentForShelf(shelf, slotIndex) {
         }
 
         function applyGameState(state) {
-            console.log("Companion receiving new game state. Active screen:", state.activePhoneScreen);
+            // STEP 1 REFACTOR: Don't log the host's screen, the companion is now in charge.
+            // console.log("Companion receiving new game state. Active screen:", state.activePhoneScreen);
 
-            // Apply all the state properties from the host to the companion's game
-            activePhoneScreen = state.activePhoneScreen;
-            phoneScreenContext = state.phoneScreenContext || {}; // IMPORTANT: Get the context
+            // Apply all the DATA properties from the host.
+            // UI state like activePhoneScreen and phoneScreenContext are now managed by the companion.
             cash = state.cash;
             day = state.day;
             shopPoints = state.shopPoints;
@@ -8690,13 +8757,15 @@ function openProductAssignmentForShelf(shelf, slotIndex) {
                 }
             }
 
+            // Update basic UI elements that are always visible.
             shelves.forEach(shelf => shelf.draw = drawShelf);
             updateUI();
             updateBasketUI();
 
-            // REFACTORED: Use the synced context to open the correct panel with the correct data.
+            // REFACTORED: Instead of changing the screen to match the host,
+            // simply REFRESH the companion's currently active screen with the new data.
             if (activePhoneScreen) {
-                console.log(`Companion refreshing active screen: ${activePhoneScreen} with context:`, phoneScreenContext);
+                console.log(`Companion has new data. Refreshing its own screen: ${activePhoneScreen}`);
                 switch (activePhoneScreen) {
                     case 'restock-panel': openRestockPanel(); break;
                     case 'unlocks-panel': openUnlocksPanel(); break;
@@ -8718,13 +8787,17 @@ function openProductAssignmentForShelf(shelf, slotIndex) {
                         break;
                     case 'storage-panel':
                         if (phoneScreenContext.cellLabel) {
-                            const cell = storageCells.find(c => c.label === phoneScreenContext.cellLabel);
+                            const cell = storageCells.find(c => c.label === phoneScreenContext.cellLabel) || coffeeShop.storage;
                             if (cell) openStorageCell(cell);
                         }
                         break;
                     case 'assignment-panel':
-                        // This screen requires more complex context, fallback to the parent
-                        openShelfAssignmentPanel();
+                        // This screen is transient, if we get a refresh here, it's best to go back.
+                        if (phoneScreenContext.shelfIndex !== undefined && shelves[phoneScreenContext.shelfIndex]) {
+                            openShelfPanel(shelves[phoneScreenContext.shelfIndex]);
+                        } else {
+                           showAppGrid(); // Fallback
+                        }
                         break;
                     case 'market-detail-panel':
                         if (phoneScreenContext.categoryKey) {
@@ -8738,8 +8811,8 @@ function openProductAssignmentForShelf(shelf, slotIndex) {
                         break;
                 }
             } else {
-                console.log("Companion returning to app grid.");
-                showAppGrid();
+                // If no screen is active, we are on the app grid. No refresh needed besides the main UI update.
+                 console.log("Companion has new data. On app grid, no screen refresh needed.");
             }
         }
 


### PR DESCRIPTION
This change refactors the companion app synchronization to make the companion device the primary controller of the phone UI.

Previously, the host dictated the UI state, which led to synchronization issues. Now, the control flow is inverted:

- The companion device now owns its UI state and sends `ui_change` messages to the host upon navigation (e.g., opening an app, going to the app grid, or closing the phone).
- The host listens for these `ui_change` messages and updates its own phone UI to mirror the companion's screen.
- A semi-transparent overlay is now displayed on the host's phone UI when a companion is connected, preventing conflicting inputs and making it clear that the UI is being controlled remotely.
- The `applyGameState` function on the companion has been refactored to only process data from the host, no longer allowing the host to dictate the companion's UI screen.