### PR TITLE
Fix: Correct TypeError in companion state synchronization

### DIFF
--- a/index.html
+++ b/index.html
@@ -1008,7 +1008,7 @@
         }
 
         let marketType = 'classic'; // Stores the player's choice. Can be 'classic', 'dailyMood', 'categoryFocus', or 'liveSimulation'.
-        const originalItemCosts = {}; // Will store a clean copy of the base item costs.
+        let originalItemCosts = {}; // Will store a clean copy of the base item costs.
         let dailyPlayerPurchases = {}; // For the 'Live Simulation' market.
 
         const marketStyleDescriptions = {
@@ -1468,7 +1468,7 @@
         });
 
 
-        const items = {
+        let items = {
             // Drawing (formerly General)
             'Pencil': { cost: 1 }, 'Charcoal': { cost: 2 }, 'Markers': { cost: 5 }, 'Sketchbook': { cost: 10 },
             // Painting (formerly Quality)


### PR DESCRIPTION
This commit resolves a `TypeError: Assignment to constant variable` that was preventing the companion device from updating its game state. The `items` and `originalItemCosts` variables were incorrectly declared as `const` but were being reassigned during the state sync process.

By changing their declarations to `let`, the state synchronization now works as expected, allowing the companion's UI to correctly reflect the host's game state.