### PR TITLE
Fix: Make phone app panels visible on click

### DIFF
--- a/index.html
+++ b/index.html
@@ -6799,6 +6799,8 @@ function showHint() {
                     buyNowOne(itemName);
                 });
             });
+
+            showAppScreen('restock-panel');
         }
 
         function openOrderQuantityModal(itemName) {
@@ -7012,6 +7014,7 @@ function showHint() {
                     purchaseUnlock(type, key);
                 });
             });
+            showAppScreen('unlocks-panel');
         }
 
 


### PR DESCRIPTION
The `openUnlocksPanel` and `openRestockPanel` functions were responsible for populating their respective UI panels but were missing the final call to `showAppScreen()` to make the panels visible.

This change adds the necessary `showAppScreen()` call to the end of both functions, ensuring that clicking the "Unlocks" and "Order" app icons correctly opens their corresponding screens.