### PR TITLE
feat: Make newspaper appear by default at day end

### DIFF
--- a/index.html
+++ b/index.html
@@ -123,6 +123,7 @@
         /* Newspaper Styles */
         .font-playfair { font-family: 'Playfair Display', serif; }
         .font-merriweather { font-family: 'Merriweather', serif; }
+        #newspaper-modal { z-index: 5000; }
         .newspaper-container {
             max-height: 90vh;
             background-image: url('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAADIAAAAyCAYAAAAeP4ixAAAAAXNSR0IArs4c6QAAADhlWElmTU0AKgAAAAgAAYdpAAQAAAABAAAAGgAAAAAAAqACAAQAAAABAAAAMqADAAQAAAABAAAAMgAAAADXPWSMAAAAcUlEQVR4Ae3aQQ0AIAwEQf//6G0pAh5Ej5oJo0yS9ACCeM3Gk2SoeDPZfGk2gT1BtybYt2T7Jtm3ZNsm2bdk2ybZt2TbJtm3ZNsm2bdk2ybZt2TbJtm3ZNsm2bdk2ybZt2TbJtm3ZNsm2bdk2ybZt2TbJtm3ZNsm2bdk2ybZt2TbJtm3ZNsm2bdk2ybZt2TbJvQG4AAdx4c33/AAAAAElFTkSuQmCC');


### PR DESCRIPTION
When the market style is "Daily Mood," the newspaper modal now appears automatically at the end of the day.

This is layered on top of the end-of-day report, allowing the user to close it and view the report afterward. The existing button on the report to re-open the newspaper remains functional.

Added a CSS rule to ensure the newspaper modal has a higher z-index than other modals.