### PR TITLE
Fix: Market report opens in report panel

### DIFF
--- a/index.html
+++ b/index.html
@@ -8372,13 +8372,6 @@ function openProductAssignmentForShelf(shelf, slotIndex) {
             const reportViews = document.querySelectorAll('.report-view');
             reportToggleButtons.forEach(button => {
                 button.addEventListener('click', () => {
-                    // SPECIAL CASE: The market button now opens the phone app.
-                    if (button.id === 'report-toggle-market') {
-                        openClipboardPanel();
-                        openMarketPanel();
-                        return; // Stop further processing for this button
-                    }
-
                     const targetViewId = button.id.replace('report-toggle-', 'report-view-');
 
                     // Toggle views


### PR DESCRIPTION
The end-of-day market report was incorrectly opening the phone UI instead of displaying the market information within the end-of-day report panel.

This was caused by a special case in the event listener for the report's navigation buttons that specifically targeted the market button to open the phone.

This commit removes the special case, allowing the market button to behave like the other report buttons and display its content within the correct panel.