### PR TITLE
feat: Transfer modals to companion device

### DIFF
--- a/jules-scratch/host_page.html
+++ b/jules-scratch/host_page.html
@@ -1,6 +1,4 @@
-<!DOCTYPE html>
-<html lang="en">
-<head>
+<!DOCTYPE html><html lang="en"><head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Art Supply Emporium</title>
@@ -9,8 +7,8 @@
     <script src="https://cdn.jsdelivr.net/npm/qrcode-generator/qrcode.js"></script>
     <script src="https://cdn.tailwindcss.com"></script>
     <link rel="preconnect" href="https://fonts.googleapis.com">
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Indie+Flower&family=Patrick+Hand&family=VT323&family=Playfair+Display:wght@700&family=Merriweather:wght@400;700&display=swap" rel="stylesheet">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="">
+    <link href="https://fonts.googleapis.com/css2?family=Indie+Flower&amp;family=Patrick+Hand&amp;family=VT323&amp;family=Playfair+Display:wght@700&amp;family=Merriweather:wght@400;700&amp;display=swap" rel="stylesheet">
     <style>
         body {
             font-family: 'Patrick Hand', cursive;
@@ -171,7 +169,7 @@
             background-color: #22c55e; /* green-500 */
         }
     </style>
-</head>
+<style>*, ::before, ::after{--tw-border-spacing-x:0;--tw-border-spacing-y:0;--tw-translate-x:0;--tw-translate-y:0;--tw-rotate:0;--tw-skew-x:0;--tw-skew-y:0;--tw-scale-x:1;--tw-scale-y:1;--tw-pan-x: ;--tw-pan-y: ;--tw-pinch-zoom: ;--tw-scroll-snap-strictness:proximity;--tw-gradient-from-position: ;--tw-gradient-via-position: ;--tw-gradient-to-position: ;--tw-ordinal: ;--tw-slashed-zero: ;--tw-numeric-figure: ;--tw-numeric-spacing: ;--tw-numeric-fraction: ;--tw-ring-inset: ;--tw-ring-offset-width:0px;--tw-ring-offset-color:#fff;--tw-ring-color:rgb(59 130 246 / 0.5);--tw-ring-offset-shadow:0 0 #0000;--tw-ring-shadow:0 0 #0000;--tw-shadow:0 0 #0000;--tw-shadow-colored:0 0 #0000;--tw-blur: ;--tw-brightness: ;--tw-contrast: ;--tw-grayscale: ;--tw-hue-rotate: ;--tw-invert: ;--tw-saturate: ;--tw-sepia: ;--tw-drop-shadow: ;--tw-backdrop-blur: ;--tw-backdrop-brightness: ;--tw-backdrop-contrast: ;--tw-backdrop-grayscale: ;--tw-backdrop-hue-rotate: ;--tw-backdrop-invert: ;--tw-backdrop-opacity: ;--tw-backdrop-saturate: ;--tw-backdrop-sepia: ;--tw-contain-size: ;--tw-contain-layout: ;--tw-contain-paint: ;--tw-contain-style: }::backdrop{--tw-border-spacing-x:0;--tw-border-spacing-y:0;--tw-translate-x:0;--tw-translate-y:0;--tw-rotate:0;--tw-skew-x:0;--tw-skew-y:0;--tw-scale-x:1;--tw-scale-y:1;--tw-pan-x: ;--tw-pan-y: ;--tw-pinch-zoom: ;--tw-scroll-snap-strictness:proximity;--tw-gradient-from-position: ;--tw-gradient-via-position: ;--tw-gradient-to-position: ;--tw-ordinal: ;--tw-slashed-zero: ;--tw-numeric-figure: ;--tw-numeric-spacing: ;--tw-numeric-fraction: ;--tw-ring-inset: ;--tw-ring-offset-width:0px;--tw-ring-offset-color:#fff;--tw-ring-color:rgb(59 130 246 / 0.5);--tw-ring-offset-shadow:0 0 #0000;--tw-ring-shadow:0 0 #0000;--tw-shadow:0 0 #0000;--tw-shadow-colored:0 0 #0000;--tw-blur: ;--tw-brightness: ;--tw-contrast: ;--tw-grayscale: ;--tw-hue-rotate: ;--tw-invert: ;--tw-saturate: ;--tw-sepia: ;--tw-drop-shadow: ;--tw-backdrop-blur: ;--tw-backdrop-brightness: ;--tw-backdrop-contrast: ;--tw-backdrop-grayscale: ;--tw-backdrop-hue-rotate: ;--tw-backdrop-invert: ;--tw-backdrop-opacity: ;--tw-backdrop-saturate: ;--tw-backdrop-sepia: ;--tw-contain-size: ;--tw-contain-layout: ;--tw-contain-paint: ;--tw-contain-style: }/* ! tailwindcss v3.4.17 | MIT License | https://tailwindcss.com */*,::after,::before{box-sizing:border-box;border-width:0;border-style:solid;border-color:#e5e7eb}::after,::before{--tw-content:''}:host,html{line-height:1.5;-webkit-text-size-adjust:100%;-moz-tab-size:4;tab-size:4;font-family:ui-sans-serif, system-ui, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";font-feature-settings:normal;font-variation-settings:normal;-webkit-tap-highlight-color:transparent}body{margin:0;line-height:inherit}hr{height:0;color:inherit;border-top-width:1px}abbr:where([title]){-webkit-text-decoration:underline dotted;text-decoration:underline dotted}h1,h2,h3,h4,h5,h6{font-size:inherit;font-weight:inherit}a{color:inherit;text-decoration:inherit}b,strong{font-weight:bolder}code,kbd,pre,samp{font-family:ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;font-feature-settings:normal;font-variation-settings:normal;font-size:1em}small{font-size:80%}sub,sup{font-size:75%;line-height:0;position:relative;vertical-align:baseline}sub{bottom:-.25em}sup{top:-.5em}table{text-indent:0;border-color:inherit;border-collapse:collapse}button,input,optgroup,select,textarea{font-family:inherit;font-feature-settings:inherit;font-variation-settings:inherit;font-size:100%;font-weight:inherit;line-height:inherit;letter-spacing:inherit;color:inherit;margin:0;padding:0}button,select{text-transform:none}button,input:where([type=button]),input:where([type=reset]),input:where([type=submit]){-webkit-appearance:button;background-color:transparent;background-image:none}:-moz-focusring{outline:auto}:-moz-ui-invalid{box-shadow:none}progress{vertical-align:baseline}::-webkit-inner-spin-button,::-webkit-outer-spin-button{height:auto}[type=search]{-webkit-appearance:textfield;outline-offset:-2px}::-webkit-search-decoration{-webkit-appearance:none}::-webkit-file-upload-button{-webkit-appearance:button;font:inherit}summary{display:list-item}blockquote,dd,dl,figure,h1,h2,h3,h4,h5,h6,hr,p,pre{margin:0}fieldset{margin:0;padding:0}legend{padding:0}menu,ol,ul{list-style:none;margin:0;padding:0}dialog{padding:0}textarea{resize:vertical}input::placeholder,textarea::placeholder{opacity:1;color:#9ca3af}[role=button],button{cursor:pointer}:disabled{cursor:default}audio,canvas,embed,iframe,img,object,svg,video{display:block;vertical-align:middle}img,video{max-width:100%;height:auto}[hidden]:where(:not([hidden=until-found])){display:none}.fixed{position:fixed}.absolute{position:absolute}.relative{position:relative}.inset-0{inset:0px}.-right-2{right:-0.5rem}.-right-4{right:-1rem}.-top-2{top:-0.5rem}.-top-4{top:-1rem}.bottom-0{bottom:0px}.bottom-2{bottom:0.5rem}.left-0{left:0px}.left-1\/2{left:50%}.left-4{left:1rem}.right-0{right:0px}.right-2{right:0.5rem}.top-0{top:0px}.top-2{top:0.5rem}.top-4{top:1rem}.top-full{top:100%}.z-10{z-index:10}.z-20{z-index:20}.m-2{margin:0.5rem}.my-1{margin-top:0.25rem;margin-bottom:0.25rem}.mb-1{margin-bottom:0.25rem}.mb-2{margin-bottom:0.5rem}.mb-4{margin-bottom:1rem}.mb-6{margin-bottom:1.5rem}.ml-2{margin-left:0.5rem}.mr-2{margin-right:0.5rem}.mt-1{margin-top:0.25rem}.mt-2{margin-top:0.5rem}.mt-4{margin-top:1rem}.mt-6{margin-top:1.5rem}.mt-auto{margin-top:auto}.block{display:block}.inline-block{display:inline-block}.flex{display:flex}.grid{display:grid}.hidden{display:none}.h-screen{height:100vh}.h-1\/5{height:20%}.h-10{height:2.5rem}.h-16{height:4rem}.h-20{height:5rem}.h-3{height:0.75rem}.h-48{height:12rem}.h-5{height:1.25rem}.h-6{height:1.5rem}.h-8{height:2rem}.h-full{height:100%}.w-1\/3{width:33.333333%}.w-10{width:2.5rem}.w-12{width:3rem}.w-16{width:4rem}.w-2\/3{width:66.666667%}.w-20{width:5rem}.w-32{width:8rem}.w-40{width:10rem}.w-48{width:12rem}.w-5{width:1.25rem}.w-6{width:1.5rem}.w-8{width:2rem}.w-full{width:100%}.max-w-2xl{max-width:42rem}.max-w-3xl{max-width:48rem}.max-w-4xl{max-width:56rem}.max-w-md{max-width:28rem}.flex-1{flex:1 1 0%}.flex-shrink-0{flex-shrink:0}.flex-grow{flex-grow:1}.-translate-x-1\/2{--tw-translate-x:-50%;transform:translate(var(--tw-translate-x), var(--tw-translate-y)) rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y))}.-translate-y-1\/2{--tw-translate-y:-50%;transform:translate(var(--tw-translate-x), var(--tw-translate-y)) rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y))}.cursor-pointer{cursor:pointer}.select-none{-webkit-user-select:none;user-select:none}.appearance-none{-webkit-appearance:none;appearance:none}.grid-cols-1{grid-template-columns:repeat(1, minmax(0, 1fr))}.grid-cols-2{grid-template-columns:repeat(2, minmax(0, 1fr))}.grid-cols-4{grid-template-columns:repeat(4, minmax(0, 1fr))}.flex-col{flex-direction:column}.items-center{align-items:center}.justify-end{justify-content:flex-end}.justify-center{justify-content:center}.justify-between{justify-content:space-between}.justify-around{justify-content:space-around}.gap-2{gap:0.5rem}.gap-4{gap:1rem}.gap-6{gap:1.5rem}.gap-x-2{column-gap:0.5rem}.gap-y-4{row-gap:1rem}.space-x-2 > :not([hidden]) ~ :not([hidden]){--tw-space-x-reverse:0;margin-right:calc(0.5rem * var(--tw-space-x-reverse));margin-left:calc(0.5rem * calc(1 - var(--tw-space-x-reverse)))}.space-x-4 > :not([hidden]) ~ :not([hidden]){--tw-space-x-reverse:0;margin-right:calc(1rem * var(--tw-space-x-reverse));margin-left:calc(1rem * calc(1 - var(--tw-space-x-reverse)))}.space-y-1 > :not([hidden]) ~ :not([hidden]){--tw-space-y-reverse:0;margin-top:calc(0.25rem * calc(1 - var(--tw-space-y-reverse)));margin-bottom:calc(0.25rem * var(--tw-space-y-reverse))}.space-y-2 > :not([hidden]) ~ :not([hidden]){--tw-space-y-reverse:0;margin-top:calc(0.5rem * calc(1 - var(--tw-space-y-reverse)));margin-bottom:calc(0.5rem * var(--tw-space-y-reverse))}.space-y-3 > :not([hidden]) ~ :not([hidden]){--tw-space-y-reverse:0;margin-top:calc(0.75rem * calc(1 - var(--tw-space-y-reverse)));margin-bottom:calc(0.75rem * var(--tw-space-y-reverse))}.space-y-4 > :not([hidden]) ~ :not([hidden]){--tw-space-y-reverse:0;margin-top:calc(1rem * calc(1 - var(--tw-space-y-reverse)));margin-bottom:calc(1rem * var(--tw-space-y-reverse))}.overflow-hidden{overflow:hidden}.overflow-y-auto{overflow-y:auto}.rounded-full{border-radius:9999px}.rounded-lg{border-radius:0.5rem}.rounded-md{border-radius:0.375rem}.rounded-sm{border-radius:0.125rem}.rounded-t-md{border-top-left-radius:0.375rem;border-top-right-radius:0.375rem}.border{border-width:1px}.border-2{border-width:2px}.border-4{border-width:4px}.border-b{border-bottom-width:1px}.border-b-2{border-bottom-width:2px}.border-b-4{border-bottom-width:4px}.border-l-2{border-left-width:2px}.border-t{border-top-width:1px}.border-t-2{border-top-width:2px}.border-double{border-style:double}.border-amber-800{--tw-border-opacity:1;border-color:rgb(146 64 14 / var(--tw-border-opacity, 1))}.border-amber-800\/10{border-color:rgb(146 64 14 / 0.1)}.border-amber-800\/20{border-color:rgb(146 64 14 / 0.2)}.border-amber-800\/30{border-color:rgb(146 64 14 / 0.3)}.border-amber-800\/50{border-color:rgb(146 64 14 / 0.5)}.border-amber-900{--tw-border-opacity:1;border-color:rgb(120 53 15 / var(--tw-border-opacity, 1))}.border-amber-900\/20{border-color:rgb(120 53 15 / 0.2)}.border-gray-300{--tw-border-opacity:1;border-color:rgb(209 213 219 / var(--tw-border-opacity, 1))}.border-purple-200{--tw-border-opacity:1;border-color:rgb(233 213 255 / var(--tw-border-opacity, 1))}.border-purple-900{--tw-border-opacity:1;border-color:rgb(88 28 135 / var(--tw-border-opacity, 1))}.border-slate-600{--tw-border-opacity:1;border-color:rgb(71 85 105 / var(--tw-border-opacity, 1))}.border-white{--tw-border-opacity:1;border-color:rgb(255 255 255 / var(--tw-border-opacity, 1))}.bg-\[\#fdf6e3\]{--tw-bg-opacity:1;background-color:rgb(253 246 227 / var(--tw-bg-opacity, 1))}.bg-amber-100{--tw-bg-opacity:1;background-color:rgb(254 243 199 / var(--tw-bg-opacity, 1))}.bg-amber-100\/80{background-color:rgb(254 243 199 / 0.8)}.bg-amber-100\/90{background-color:rgb(254 243 199 / 0.9)}.bg-amber-50{--tw-bg-opacity:1;background-color:rgb(255 251 235 / var(--tw-bg-opacity, 1))}.bg-amber-800{--tw-bg-opacity:1;background-color:rgb(146 64 14 / var(--tw-bg-opacity, 1))}.bg-amber-800\/20{background-color:rgb(146 64 14 / 0.2)}.bg-black\/50{background-color:rgb(0 0 0 / 0.5)}.bg-black\/60{background-color:rgb(0 0 0 / 0.6)}.bg-black\/70{background-color:rgb(0 0 0 / 0.7)}.bg-blue-500{--tw-bg-opacity:1;background-color:rgb(59 130 246 / var(--tw-bg-opacity, 1))}.bg-blue-600{--tw-bg-opacity:1;background-color:rgb(37 99 235 / var(--tw-bg-opacity, 1))}.bg-gray-300{--tw-bg-opacity:1;background-color:rgb(209 213 219 / var(--tw-bg-opacity, 1))}.bg-green-500{--tw-bg-opacity:1;background-color:rgb(34 197 94 / var(--tw-bg-opacity, 1))}.bg-green-700{--tw-bg-opacity:1;background-color:rgb(21 128 61 / var(--tw-bg-opacity, 1))}.bg-purple-100\/50{background-color:rgb(243 232 255 / 0.5)}.bg-red-600{--tw-bg-opacity:1;background-color:rgb(220 38 38 / var(--tw-bg-opacity, 1))}.bg-red-700{--tw-bg-opacity:1;background-color:rgb(185 28 28 / var(--tw-bg-opacity, 1))}.bg-slate-400{--tw-bg-opacity:1;background-color:rgb(148 163 184 / var(--tw-bg-opacity, 1))}.bg-slate-600{--tw-bg-opacity:1;background-color:rgb(71 85 105 / var(--tw-bg-opacity, 1))}.bg-white{--tw-bg-opacity:1;background-color:rgb(255 255 255 / var(--tw-bg-opacity, 1))}.bg-white\/30{background-color:rgb(255 255 255 / 0.3)}.bg-white\/40{background-color:rgb(255 255 255 / 0.4)}.bg-white\/50{background-color:rgb(255 255 255 / 0.5)}.bg-white\/80{background-color:rgb(255 255 255 / 0.8)}.bg-opacity-50{--tw-bg-opacity:0.5}.bg-gradient-to-b{background-image:linear-gradient(to bottom, var(--tw-gradient-stops))}.from-slate-300{--tw-gradient-from:#cbd5e1 var(--tw-gradient-from-position);--tw-gradient-to:rgb(203 213 225 / 0) var(--tw-gradient-to-position);--tw-gradient-stops:var(--tw-gradient-from), var(--tw-gradient-to)}.to-slate-500{--tw-gradient-to:#64748b var(--tw-gradient-to-position)}.p-4{padding:1rem}.p-1{padding:0.25rem}.p-2{padding:0.5rem}.p-3{padding:0.75rem}.p-6{padding:1.5rem}.px-3{padding-left:0.75rem;padding-right:0.75rem}.px-4{padding-left:1rem;padding-right:1rem}.px-6{padding-left:1.5rem;padding-right:1.5rem}.px-8{padding-left:2rem;padding-right:2rem}.py-1{padding-top:0.25rem;padding-bottom:0.25rem}.py-2{padding-top:0.5rem;padding-bottom:0.5rem}.py-3{padding-top:0.75rem;padding-bottom:0.75rem}.pb-2{padding-bottom:0.5rem}.pb-4{padding-bottom:1rem}.pl-4{padding-left:1rem}.pt-16{padding-top:4rem}.pt-2{padding-top:0.5rem}.text-center{text-align:center}.align-middle{vertical-align:middle}.text-2xl{font-size:1.5rem;line-height:2rem}.text-3xl{font-size:1.875rem;line-height:2.25rem}.text-5xl{font-size:3rem;line-height:1}.text-base{font-size:1rem;line-height:1.5rem}.text-lg{font-size:1.125rem;line-height:1.75rem}.text-sm{font-size:0.875rem;line-height:1.25rem}.text-xl{font-size:1.25rem;line-height:1.75rem}.text-xs{font-size:0.75rem;line-height:1rem}.font-bold{font-weight:700}.leading-relaxed{line-height:1.625}.text-amber-800\/80{color:rgb(146 64 14 / 0.8)}.text-amber-900{--tw-text-opacity:1;color:rgb(120 53 15 / var(--tw-text-opacity, 1))}.text-gray-600{--tw-text-opacity:1;color:rgb(75 85 99 / var(--tw-text-opacity, 1))}.text-gray-700{--tw-text-opacity:1;color:rgb(55 65 81 / var(--tw-text-opacity, 1))}.text-gray-800{--tw-text-opacity:1;color:rgb(31 41 55 / var(--tw-text-opacity, 1))}.text-green-500{--tw-text-opacity:1;color:rgb(34 197 94 / var(--tw-text-opacity, 1))}.text-purple-900{--tw-text-opacity:1;color:rgb(88 28 135 / var(--tw-text-opacity, 1))}.text-red-500{--tw-text-opacity:1;color:rgb(239 68 68 / var(--tw-text-opacity, 1))}.text-white{--tw-text-opacity:1;color:rgb(255 255 255 / var(--tw-text-opacity, 1))}.shadow-2xl{--tw-shadow:0 25px 50px -12px rgb(0 0 0 / 0.25);--tw-shadow-colored:0 25px 50px -12px var(--tw-shadow-color);box-shadow:var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow)}.shadow-lg{--tw-shadow:0 10px 15px -3px rgb(0 0 0 / 0.1), 0 4px 6px -4px rgb(0 0 0 / 0.1);--tw-shadow-colored:0 10px 15px -3px var(--tw-shadow-color), 0 4px 6px -4px var(--tw-shadow-color);box-shadow:var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow)}.shadow-md{--tw-shadow:0 4px 6px -1px rgb(0 0 0 / 0.1), 0 2px 4px -2px rgb(0 0 0 / 0.1);--tw-shadow-colored:0 4px 6px -1px var(--tw-shadow-color), 0 2px 4px -2px var(--tw-shadow-color);box-shadow:var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow)}.shadow-xl{--tw-shadow:0 20px 25px -5px rgb(0 0 0 / 0.1), 0 8px 10px -6px rgb(0 0 0 / 0.1);--tw-shadow-colored:0 20px 25px -5px var(--tw-shadow-color), 0 8px 10px -6px var(--tw-shadow-color);box-shadow:var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow)}.backdrop-blur-sm{--tw-backdrop-blur:blur(4px);-webkit-backdrop-filter:var(--tw-backdrop-blur) var(--tw-backdrop-brightness) var(--tw-backdrop-contrast) var(--tw-backdrop-grayscale) var(--tw-backdrop-hue-rotate) var(--tw-backdrop-invert) var(--tw-backdrop-opacity) var(--tw-backdrop-saturate) var(--tw-backdrop-sepia);backdrop-filter:var(--tw-backdrop-blur) var(--tw-backdrop-brightness) var(--tw-backdrop-contrast) var(--tw-backdrop-grayscale) var(--tw-backdrop-hue-rotate) var(--tw-backdrop-invert) var(--tw-backdrop-opacity) var(--tw-backdrop-saturate) var(--tw-backdrop-sepia)}.transition{transition-property:color, background-color, border-color, fill, stroke, opacity, box-shadow, transform, filter, -webkit-text-decoration-color, -webkit-backdrop-filter;transition-property:color, background-color, border-color, text-decoration-color, fill, stroke, opacity, box-shadow, transform, filter, backdrop-filter;transition-property:color, background-color, border-color, text-decoration-color, fill, stroke, opacity, box-shadow, transform, filter, backdrop-filter, -webkit-text-decoration-color, -webkit-backdrop-filter;transition-timing-function:cubic-bezier(0.4, 0, 0.2, 1);transition-duration:150ms}.transition-all{transition-property:all;transition-timing-function:cubic-bezier(0.4, 0, 0.2, 1);transition-duration:150ms}.transition-transform{transition-property:transform;transition-timing-function:cubic-bezier(0.4, 0, 0.2, 1);transition-duration:150ms}.duration-200{transition-duration:200ms}.ease-in{transition-timing-function:cubic-bezier(0.4, 0, 1, 1)}.hover\:scale-110:hover{--tw-scale-x:1.1;--tw-scale-y:1.1;transform:translate(var(--tw-translate-x), var(--tw-translate-y)) rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y))}.hover\:bg-blue-500:hover{--tw-bg-opacity:1;background-color:rgb(59 130 246 / var(--tw-bg-opacity, 1))}.hover\:bg-green-600:hover{--tw-bg-opacity:1;background-color:rgb(22 163 74 / var(--tw-bg-opacity, 1))}.hover\:bg-red-600:hover{--tw-bg-opacity:1;background-color:rgb(220 38 38 / var(--tw-bg-opacity, 1))}.hover\:text-red-700:hover{--tw-text-opacity:1;color:rgb(185 28 28 / var(--tw-text-opacity, 1))}</style></head>
 <body class="p-4 flex flex-col items-center justify-center h-screen">
 
     <!-- The main container for the game canvas and its overlay UI -->
@@ -179,7 +177,7 @@
         <!-- The UI that sits on top of the canvas -->
         <div id="game-ui" class="absolute top-4 left-4 z-10 flex items-center space-x-4">
              <div class="relative overflow-hidden p-3 text-xl border-2 border-amber-900 rounded-lg bg-amber-100/80 shadow-md backdrop-blur-sm">
-                 $<span id="cash-display">0</span>
+                 $<span id="cash-display">100</span>
                  <div id="cash-progress-bar" class="absolute bottom-0 left-0 h-1/5 bg-green-500 transition-all duration-200" style="width: 0%;"></div>
              </div>
              <div class="p-3 text-xl border-2 border-amber-900 rounded-lg bg-amber-100/80 shadow-md backdrop-blur-sm">
@@ -215,7 +213,7 @@
         </div>
 
         <!-- Canvas for the game -->
-        <canvas id="game-canvas" class="rounded-lg shadow-xl w-full h-full"></canvas>
+        <canvas id="game-canvas" class="rounded-lg shadow-xl w-full h-full" width="1244" height="684"></canvas>
 
         <!-- Hidden canvas for generating the sprite sheet -->
         <canvas id="spriteSheetCanvas" width="270" height="270" style="display:none;"></canvas>
@@ -258,14 +256,14 @@
                             <div class="flex items-center justify-between p-2 bg-white/50 rounded-md">
                                 <label for="developer-toggle" class="text-lg">Developer Mode</label>
                                 <div class="relative inline-block w-12 mr-2 align-middle select-none transition duration-200 ease-in">
-                                    <input type="checkbox" name="developer-toggle" id="developer-toggle" class="toggle-checkbox absolute block w-6 h-6 rounded-full bg-white border-4 appearance-none cursor-pointer"/>
+                                    <input type="checkbox" name="developer-toggle" id="developer-toggle" class="toggle-checkbox absolute block w-6 h-6 rounded-full bg-white border-4 appearance-none cursor-pointer">
                                     <label for="developer-toggle" class="toggle-label block overflow-hidden h-6 rounded-full bg-gray-300 cursor-pointer"></label>
                                 </div>
                             </div>
                             <div class="flex items-center justify-between p-2 bg-white/50 rounded-md">
                                 <label for="continuous-toggle" class="text-lg">Continuous Day</label>
                                 <div class="relative inline-block w-12 mr-2 align-middle select-none transition duration-200 ease-in">
-                                    <input type="checkbox" name="continuous-toggle" id="continuous-toggle" class="toggle-checkbox absolute block w-6 h-6 rounded-full bg-white border-4 appearance-none cursor-pointer"/>
+                                    <input type="checkbox" name="continuous-toggle" id="continuous-toggle" class="toggle-checkbox absolute block w-6 h-6 rounded-full bg-white border-4 appearance-none cursor-pointer">
                                     <label for="continuous-toggle" class="toggle-label block overflow-hidden h-6 rounded-full bg-gray-300 cursor-pointer"></label>
                                 </div>
                             </div>
@@ -362,7 +360,7 @@
                             <button id="in-store-customers-btn" class="flex-1 p-2 bg-amber-800/20 rounded-t-md">In Store</button>
                             <button id="all-customers-btn" class="flex-1 p-2 bg-amber-800/20 rounded-t-md bg-opacity-50">All</button>
                         </div>
-                        <div id="in-store-customer-list" class="space-y-2"></div>
+                        <div id="in-store-customer-list" class="space-y-2"><p class="text-center p-4">No customers in the shop.</p></div>
                         <div id="all-customer-list" class="hidden flex-col space-y-2"></div>
                     </div>
 
@@ -417,9 +415,9 @@
     </div>
 
     <!-- New Game Screen -->
-    <div id="new-game-screen" class="hidden fixed inset-0 bg-black/50 flex items-center justify-center z-3000">
+    <div id="new-game-screen" class="fixed inset-0 bg-black/50 flex items-center justify-center z-3000">
         <div class="relative bg-amber-100 w-full max-w-2xl p-6 rounded-lg shadow-xl border-4 border-amber-900 text-amber-900 flex flex-col">
-            <button id="close-new-game-screen" class="absolute top-2 right-2 text-3xl font-bold text-amber-900 hover:text-red-700">&times;</button>
+            <button id="close-new-game-screen" class="absolute top-2 right-2 text-3xl font-bold text-amber-900 hover:text-red-700">×</button>
             <h2 class="text-3xl font-handwritten text-center mb-6">Start a New Game</h2>
             <div class="space-y-4">
                 <button id="new-game-standard" class="btn-style p-4 text-xl w-full">Standard Unlocks</button>
@@ -446,28 +444,28 @@
                 <div class="flex items-center justify-between p-2 bg-white/50 rounded-md">
                     <label id="dev-unlocks-label" for="dev-unlocks-toggle" class="text-lg">Standard</label>
                     <div class="relative inline-block w-12 mr-2 align-middle select-none transition duration-200 ease-in">
-                        <input type="checkbox" name="dev-unlocks-toggle" id="dev-unlocks-toggle" class="toggle-checkbox absolute block w-6 h-6 rounded-full bg-white border-4 appearance-none cursor-pointer"/>
+                        <input type="checkbox" name="dev-unlocks-toggle" id="dev-unlocks-toggle" class="toggle-checkbox absolute block w-6 h-6 rounded-full bg-white border-4 appearance-none cursor-pointer">
                         <label for="dev-unlocks-toggle" class="toggle-label block overflow-hidden h-6 rounded-full bg-gray-300 cursor-pointer"></label>
                     </div>
                 </div>
                 <div class="flex items-center justify-between p-2 bg-white/50 rounded-md">
                     <label id="dev-supplies-label" for="dev-supplies-toggle" class="text-lg">Standard Costs</label>
                     <div class="relative inline-block w-12 mr-2 align-middle select-none transition duration-200 ease-in">
-                        <input type="checkbox" name="dev-supplies-toggle" id="dev-supplies-toggle" class="toggle-checkbox absolute block w-6 h-6 rounded-full bg-white border-4 appearance-none cursor-pointer"/>
+                        <input type="checkbox" name="dev-supplies-toggle" id="dev-supplies-toggle" class="toggle-checkbox absolute block w-6 h-6 rounded-full bg-white border-4 appearance-none cursor-pointer">
                         <label for="dev-supplies-toggle" class="toggle-label block overflow-hidden h-6 rounded-full bg-gray-300 cursor-pointer"></label>
                     </div>
                 </div>
                 <div class="flex items-center justify-between p-2 bg-white/50 rounded-md">
                     <label id="dev-debt-label" for="dev-debt-toggle" class="text-lg">Standard Debt</label>
                     <div class="relative inline-block w-12 mr-2 align-middle select-none transition duration-200 ease-in">
-                        <input type="checkbox" name="dev-debt-toggle" id="dev-debt-toggle" class="toggle-checkbox absolute block w-6 h-6 rounded-full bg-white border-4 appearance-none cursor-pointer"/>
+                        <input type="checkbox" name="dev-debt-toggle" id="dev-debt-toggle" class="toggle-checkbox absolute block w-6 h-6 rounded-full bg-white border-4 appearance-none cursor-pointer">
                         <label for="dev-debt-toggle" class="toggle-label block overflow-hidden h-6 rounded-full bg-gray-300 cursor-pointer"></label>
                     </div>
                 </div>
                 <div class="flex items-center justify-between p-2 bg-white/50 rounded-md">
                     <label id="dev-market-label" for="dev-market-toggle" class="text-lg">Market</label>
                     <div class="relative inline-block w-12 mr-2 align-middle select-none transition duration-200 ease-in">
-                        <input type="checkbox" name="dev-market-toggle" id="dev-market-toggle" class="toggle-checkbox absolute block w-6 h-6 rounded-full bg-white border-4 appearance-none cursor-pointer"/>
+                        <input type="checkbox" name="dev-market-toggle" id="dev-market-toggle" class="toggle-checkbox absolute block w-6 h-6 rounded-full bg-white border-4 appearance-none cursor-pointer">
                         <label for="dev-market-toggle" class="toggle-label block overflow-hidden h-6 rounded-full bg-gray-300 cursor-pointer"></label>
                     </div>
                 </div>
@@ -492,21 +490,21 @@
                 <div class="flex items-center justify-between p-2 bg-white/50 rounded-md">
                     <label id="family-coffee-label" for="family-coffee-toggle" class="text-lg">Free Coffee Shop</label>
                     <div class="relative inline-block w-12 mr-2 align-middle select-none transition duration-200 ease-in">
-                        <input type="checkbox" name="family-coffee-toggle" id="family-coffee-toggle" class="toggle-checkbox absolute block w-6 h-6 rounded-full bg-white border-4 appearance-none cursor-pointer"/>
+                        <input type="checkbox" name="family-coffee-toggle" id="family-coffee-toggle" class="toggle-checkbox absolute block w-6 h-6 rounded-full bg-white border-4 appearance-none cursor-pointer">
                         <label for="family-coffee-toggle" class="toggle-label block overflow-hidden h-6 rounded-full bg-gray-300 cursor-pointer"></label>
                     </div>
                 </div>
                 <div class="flex items-center justify-between p-2 bg-white/50 rounded-md">
                     <label id="family-costs-label" for="family-costs-toggle" class="text-lg">Bad Costs</label>
                     <div class="relative inline-block w-12 mr-2 align-middle select-none transition duration-200 ease-in">
-                        <input type="checkbox" name="family-costs-toggle" id="family-costs-toggle" class="toggle-checkbox absolute block w-6 h-6 rounded-full bg-white border-4 appearance-none cursor-pointer"/>
+                        <input type="checkbox" name="family-costs-toggle" id="family-costs-toggle" class="toggle-checkbox absolute block w-6 h-6 rounded-full bg-white border-4 appearance-none cursor-pointer">
                         <label for="family-costs-toggle" class="toggle-label block overflow-hidden h-6 rounded-full bg-gray-300 cursor-pointer"></label>
                     </div>
                 </div>
                 <div class="flex items-center justify-between p-2 bg-white/50 rounded-md">
                     <label id="family-sales-label" for="family-sales-toggle" class="text-lg">Bad Sales</label>
                     <div class="relative inline-block w-12 mr-2 align-middle select-none transition duration-200 ease-in">
-                        <input type="checkbox" name="family-sales-toggle" id="family-sales-toggle" class="toggle-checkbox absolute block w-6 h-6 rounded-full bg-white border-4 appearance-none cursor-pointer"/>
+                        <input type="checkbox" name="family-sales-toggle" id="family-sales-toggle" class="toggle-checkbox absolute block w-6 h-6 rounded-full bg-white border-4 appearance-none cursor-pointer">
                         <label for="family-sales-toggle" class="toggle-label block overflow-hidden h-6 rounded-full bg-gray-300 cursor-pointer"></label>
                     </div>
                 </div>
@@ -515,7 +513,7 @@
                     <label for="family-relative-select" class="text-lg">Choose Relative</label>
                     <select id="family-relative-select" class="p-2 rounded-md border-2 border-amber-800/50 bg-white/80">
                         <!-- Options will be populated by JS -->
-                    </select>
+                    <option value="cashier">Cashier</option><option value="stocker">Stocker</option><option value="barista">Barista</option><option value="manager">Manager</option><option value="salesperson">Salesperson</option></select>
                 </div>
             </div>
             <div class="flex justify-between items-center">
@@ -534,32 +532,32 @@
                 <div class="grid grid-cols-2 gap-4">
                     <div class="flex flex-col space-y-2">
                         <label for="specialty-one-select" class="text-lg">Primary Specialty</label>
-                        <select id="specialty-one-select" class="p-2 rounded-md border-2 border-amber-800/50 bg-white/80"></select>
+                        <select id="specialty-one-select" class="p-2 rounded-md border-2 border-amber-800/50 bg-white/80"><option value="Drawing">Drawing</option><option value="Painting">Painting</option><option value="Models">Models</option><option value="Woodworking">Woodworking</option><option value="Sculpture">Sculpture</option><option value="Architectural">Architectural</option></select>
                     </div>
                     <div class="flex flex-col space-y-2">
                         <label for="specialty-two-select" class="text-lg">Secondary Specialty</label>
-                        <select id="specialty-two-select" class="p-2 rounded-md border-2 border-amber-800/50 bg-white/80"></select>
+                        <select id="specialty-two-select" class="p-2 rounded-md border-2 border-amber-800/50 bg-white/80"><option value="None">None</option><option value="Drawing" disabled="">Drawing</option><option value="Painting">Painting</option><option value="Models">Models</option><option value="Woodworking">Woodworking</option><option value="Sculpture">Sculpture</option><option value="Architectural">Architectural</option></select>
                     </div>
                 </div>
                 <!-- Toggles -->
                 <div class="flex items-center justify-between p-2 bg-white/50 rounded-md">
                     <label id="specialty-costs-label" for="specialty-costs-toggle" class="text-lg">-10% Prices</label>
                     <div class="relative inline-block w-12 mr-2 align-middle select-none transition duration-200 ease-in">
-                        <input type="checkbox" name="specialty-costs-toggle" id="specialty-costs-toggle" class="toggle-checkbox absolute block w-6 h-6 rounded-full bg-white border-4 appearance-none cursor-pointer"/>
+                        <input type="checkbox" name="specialty-costs-toggle" id="specialty-costs-toggle" class="toggle-checkbox absolute block w-6 h-6 rounded-full bg-white border-4 appearance-none cursor-pointer">
                         <label for="specialty-costs-toggle" class="toggle-label block overflow-hidden h-6 rounded-full bg-gray-300 cursor-pointer"></label>
                     </div>
                 </div>
                 <div class="flex items-center justify-between p-2 bg-white/50 rounded-md">
                     <label id="specialty-coffee-label" for="specialty-coffee-toggle" class="text-lg">No Coffee Shop</label>
                     <div class="relative inline-block w-12 mr-2 align-middle select-none transition duration-200 ease-in">
-                        <input type="checkbox" name="specialty-coffee-toggle" id="specialty-coffee-toggle" class="toggle-checkbox absolute block w-6 h-6 rounded-full bg-white border-4 appearance-none cursor-pointer"/>
+                        <input type="checkbox" name="specialty-coffee-toggle" id="specialty-coffee-toggle" class="toggle-checkbox absolute block w-6 h-6 rounded-full bg-white border-4 appearance-none cursor-pointer">
                         <label for="specialty-coffee-toggle" class="toggle-label block overflow-hidden h-6 rounded-full bg-gray-300 cursor-pointer"></label>
                     </div>
                 </div>
                 <div class="flex items-center justify-between p-2 bg-white/50 rounded-md">
                     <label id="specialty-customers-label" for="specialty-customers-toggle" class="text-lg">Increase Customer Pool</label>
                     <div class="relative inline-block w-12 mr-2 align-middle select-none transition duration-200 ease-in">
-                        <input type="checkbox" name="specialty-customers-toggle" id="specialty-customers-toggle" class="toggle-checkbox absolute block w-6 h-6 rounded-full bg-white border-4 appearance-none cursor-pointer"/>
+                        <input type="checkbox" name="specialty-customers-toggle" id="specialty-customers-toggle" class="toggle-checkbox absolute block w-6 h-6 rounded-full bg-white border-4 appearance-none cursor-pointer">
                         <label for="specialty-customers-toggle" class="toggle-label block overflow-hidden h-6 rounded-full bg-gray-300 cursor-pointer"></label>
                     </div>
                 </div>
@@ -580,14 +578,14 @@
                 <div class="flex items-center justify-between p-2 bg-white/50 rounded-md">
                     <label for="casual-breaks-toggle" class="text-lg">No Breaks</label>
                     <div class="relative inline-block w-12 mr-2 align-middle select-none transition duration-200 ease-in">
-                        <input type="checkbox" name="casual-breaks-toggle" id="casual-breaks-toggle" class="toggle-checkbox absolute block w-6 h-6 rounded-full bg-white border-4 appearance-none cursor-pointer"/>
+                        <input type="checkbox" name="casual-breaks-toggle" id="casual-breaks-toggle" class="toggle-checkbox absolute block w-6 h-6 rounded-full bg-white border-4 appearance-none cursor-pointer">
                         <label for="casual-breaks-toggle" class="toggle-label block overflow-hidden h-6 rounded-full bg-gray-300 cursor-pointer"></label>
                     </div>
                 </div>
                 <div class="flex items-center justify-between p-2 bg-white/50 rounded-md">
                     <label for="casual-debt-toggle" class="text-lg">No Debt Penalty</label>
                     <div class="relative inline-block w-12 mr-2 align-middle select-none transition duration-200 ease-in">
-                        <input type="checkbox" name="casual-debt-toggle" id="casual-debt-toggle" class="toggle-checkbox absolute block w-6 h-6 rounded-full bg-white border-4 appearance-none cursor-pointer"/>
+                        <input type="checkbox" name="casual-debt-toggle" id="casual-debt-toggle" class="toggle-checkbox absolute block w-6 h-6 rounded-full bg-white border-4 appearance-none cursor-pointer">
                         <label for="casual-debt-toggle" class="toggle-label block overflow-hidden h-6 rounded-full bg-gray-300 cursor-pointer"></label>
                     </div>
                 </div>
@@ -619,7 +617,7 @@
                 <div class="flex items-center justify-between p-2 bg-white/50 rounded-md">
                     <label for="final-continuous-day-toggle" class="text-lg">Continuous Day</label>
                     <div class="relative inline-block w-12 mr-2 align-middle select-none transition duration-200 ease-in">
-                        <input type="checkbox" name="final-continuous-day-toggle" id="final-continuous-day-toggle" class="toggle-checkbox absolute block w-6 h-6 rounded-full bg-white border-4 appearance-none cursor-pointer"/>
+                        <input type="checkbox" name="final-continuous-day-toggle" id="final-continuous-day-toggle" class="toggle-checkbox absolute block w-6 h-6 rounded-full bg-white border-4 appearance-none cursor-pointer">
                         <label for="final-continuous-day-toggle" class="toggle-label block overflow-hidden h-6 rounded-full bg-gray-300 cursor-pointer"></label>
                     </div>
                 </div>
@@ -659,7 +657,7 @@
     <!-- Newspaper Modal -->
     <div id="newspaper-modal" class="hidden fixed inset-0 bg-black/60 flex items-center justify-center z-5000 p-4">
         <div class="bg-[#fdf6e3] w-full max-w-3xl p-6 rounded-lg shadow-2xl border-4 border-amber-900 text-amber-900 flex flex-col relative newspaper-container">
-            <button id="close-newspaper-btn" class="absolute -top-4 -right-4 bg-red-700 text-white rounded-full w-10 h-10 text-2xl font-bold border-4 border-white hover:bg-red-600 transition-transform hover:scale-110">&times;</button>
+            <button id="close-newspaper-btn" class="absolute -top-4 -right-4 bg-red-700 text-white rounded-full w-10 h-10 text-2xl font-bold border-4 border-white hover:bg-red-600 transition-transform hover:scale-110">×</button>
             <div class="text-center mb-4">
                 <h1 class="font-playfair text-5xl font-bold text-purple-900 pb-2 border-b-4 border-double border-purple-900">The Bumble Bee</h1>
                 <p class="text-lg text-gray-600 mt-2">Edition: Day <span id="newspaper-day">1</span></p>
@@ -684,7 +682,7 @@
                 <h2 class="text-3xl font-handwritten text-center">End of Day Report</h2>
                 <button id="eod-newspaper-btn" class="absolute right-0 btn-style p-2 hidden" title="Read Today's News">
                     <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
-                        <path stroke-linecap="round" stroke-linejoin="round" d="M19 20H5a2 2 0 01-2-2V6a2 2 0 012-2h10a2 2 0 012 2v1m2 13a2 2 0 01-2-2V7m2 13a2 2 0 002-2V9a2 2 0 00-2-2h-2m-4-3H9M7 16h6M7 12h6m-6-4h6" />
+                        <path stroke-linecap="round" stroke-linejoin="round" d="M19 20H5a2 2 0 01-2-2V6a2 2 0 012-2h10a2 2 0 012 2v1m2 13a2 2 0 01-2-2V7m2 13a2 2 0 002-2V9a2 2 0 00-2-2h-2m-4-3H9M7 16h6M7 12h6m-6-4h6"></path>
                     </svg>
                 </button>
             </div>
@@ -754,7 +752,7 @@
         <div class="bg-amber-100 w-full max-w-2xl p-6 rounded-lg shadow-xl border-4 border-amber-900 text-amber-900 flex flex-col">
             <div class="flex justify-between items-center mb-4">
                 <h2 class="text-3xl font-handwritten">Manager's Report</h2>
-                <button id="close-manager-report-btn" class="text-3xl font-bold text-amber-900 hover:text-red-700">&times;</button>
+                <button id="close-manager-report-btn" class="text-3xl font-bold text-amber-900 hover:text-red-700">×</button>
             </div>
             <div class="flex-grow bg-white/50 p-4 rounded-md border-2 border-amber-800/30">
                 <h3 class="text-xl font-handwritten border-b-2 border-amber-800/30 mb-2">Upcoming Trends</h3>
@@ -773,7 +771,7 @@
         <div class="bg-amber-100 w-full max-w-3xl p-6 rounded-lg shadow-xl border-4 border-amber-900 text-amber-900 flex flex-col" style="height: 80vh;">
             <div class="flex justify-between items-center mb-4 flex-shrink-0">
                 <h2 class="text-3xl font-handwritten">Developer Forecast Report</h2>
-                <button id="close-dev-report-btn" class="text-3xl font-bold text-amber-900 hover:text-red-700">&times;</button>
+                <button id="close-dev-report-btn" class="text-3xl font-bold text-amber-900 hover:text-red-700">×</button>
             </div>
             <div id="dev-report-content" class="flex-grow bg-white/50 p-4 rounded-md border-2 border-amber-800/30 overflow-y-auto">
                 <!-- Content will be populated by JS -->
@@ -786,7 +784,7 @@
         <div class="bg-amber-50 w-full max-w-4xl p-6 rounded-lg shadow-2xl border-4 border-amber-900 text-amber-900 flex flex-col" style="height: 90vh;">
             <div class="flex justify-between items-center mb-4 flex-shrink-0">
                 <h2 id="simulated-report-title" class="text-3xl font-handwritten">Simulated Market Report</h2>
-                <button id="close-simulated-report-btn" class="text-3xl font-bold text-amber-900 hover:text-red-700">&times;</button>
+                <button id="close-simulated-report-btn" class="text-3xl font-bold text-amber-900 hover:text-red-700">×</button>
             </div>
             <div id="simulated-market-report-content" class="flex-grow bg-white/40 p-4 rounded-md border-2 border-amber-800/30 overflow-y-auto">
                 <!-- Simulated content will be populated by JS -->
@@ -799,7 +797,7 @@
         <div class="relative bg-amber-100 w-full max-w-2xl p-6 rounded-lg shadow-xl border-4 border-amber-900 text-amber-900 flex flex-col" style="height: 80vh;">
             <div class="flex justify-between items-center mb-4 flex-shrink-0">
                 <h2 class="text-3xl font-handwritten">Market Report</h2>
-                <button id="close-market-panel-btn" class="text-3xl font-bold text-amber-900 hover:text-red-700">&times;</button>
+                <button id="close-market-panel-btn" class="text-3xl font-bold text-amber-900 hover:text-red-700">×</button>
             </div>
             <div id="market-categories-container" class="space-y-2 flex-grow overflow-y-auto p-2 bg-white/30 rounded-md border">
                 <!-- Category reports will be dynamically inserted here -->
@@ -814,7 +812,7 @@
                 <h2 id="market-detail-title" class="text-3xl font-handwritten">Category Details</h2>
                 <div>
                      <button id="market-detail-back-btn" class="btn-style px-4 py-1 mr-2">Back</button>
-                     <button id="close-market-detail-panel-btn" class="text-3xl font-bold text-amber-900 hover:text-red-700">&times;</button>
+                     <button id="close-market-detail-panel-btn" class="text-3xl font-bold text-amber-900 hover:text-red-700">×</button>
                 </div>
             </div>
             <div id="market-items-container" class="space-y-2 flex-grow overflow-y-auto p-2 bg-white/30 rounded-md border">
@@ -830,7 +828,7 @@
                 <h2 id="market-deep-dive-title" class="text-3xl font-handwritten">Item Details</h2>
                 <div>
                     <button id="market-deep-dive-back-btn" class="btn-style px-4 py-1 mr-2">Back</button>
-                    <button id="close-market-deep-dive-panel-btn" class="text-3xl font-bold text-amber-900 hover:text-red-700">&times;</button>
+                    <button id="close-market-deep-dive-panel-btn" class="text-3xl font-bold text-amber-900 hover:text-red-700">×</button>
                 </div>
             </div>
             <div class="space-y-4 flex-grow overflow-y-auto p-2">
@@ -8317,11 +8315,11 @@ function openProductAssignmentForShelf(shelf, slotIndex) {
         }
 
         function showScreen(screenId) {
-            currentModalScreen = screenId;
             // If we are the host with a connection, send the screen change to the companion.
             if (hostConnection && hostConnection.open) {
+                currentModalScreen = screenId;
                 sendFullGameStateToCompanion();
-                // Don't show the modal on the host screen, the companion will show it.
+                // Don't show the modal on the host screen
                 return;
             }
             const screen = document.getElementById(screenId);
@@ -8329,17 +8327,17 @@ function openProductAssignmentForShelf(shelf, slotIndex) {
         }
 
         function hideScreen(screenId) {
-            const screen = document.getElementById(screenId);
-            if (screen) screen.classList.add('hidden');
-
-            // If we are hiding the currently active modal, clear the state.
-            if (currentModalScreen === screenId) {
-                currentModalScreen = null;
-                // If we are the host, send the update to the companion.
-                if (hostConnection && hostConnection.open) {
+            // If we are the host with a connection, update state for the companion.
+            if (hostConnection && hostConnection.open) {
+                if (currentModalScreen === screenId) {
+                    currentModalScreen = null;
                     sendFullGameStateToCompanion();
                 }
             }
+            // Always hide the element on the host. This handles cases where a companion
+            // disconnects or for non-companion play.
+            const screen = document.getElementById(screenId);
+            if (screen) screen.classList.add('hidden');
         }
 
         function startGame(options = {}) {
@@ -8360,9 +8358,6 @@ function openProductAssignmentForShelf(shelf, slotIndex) {
             // 2. Reset everything
             localStorage.removeItem('artEmporiumSave');
             resetGameState();
-
-            // 3. Initialize layout AFTER resetting state
-            initializeLayout();
 
             // 3. Apply options from the config object
             if (options.dev) {
@@ -9525,5 +9520,6 @@ function openProductAssignmentForShelf(shelf, slotIndex) {
         }
 
     </script>
-</body>
-</html>
+
+
+</body></html>

--- a/jules-scratch/verification/verify_companion_modals.py
+++ b/jules-scratch/verification/verify_companion_modals.py
@@ -1,0 +1,73 @@
+import asyncio
+import re
+from playwright.async_api import async_playwright, expect
+import os
+
+async def main():
+    async with async_playwright() as p:
+        browser = await p.chromium.launch(headless=True)
+
+        # Get the absolute path for the index.html file
+        index_path = "file://" + os.path.abspath("index.html")
+
+        # --- Host Setup ---
+        host_context = await browser.new_context()
+        host_page = await host_context.new_page()
+        await host_page.goto(index_path)
+
+        # The "New Game" modal should be visible on the host initially
+        await expect(host_page.locator("#new-game-screen")).to_be_visible()
+        print("Host: Initial 'New Game' modal is visible.")
+
+        # Click the companion sync button to open the QR code modal
+        # Force the click because the "New Game" modal may be obscuring it.
+        await host_page.locator("#companion-sync-btn").click(force=True)
+        await expect(host_page.locator("#host-sync-modal")).to_be_visible()
+        print("Host: QR code modal is visible.")
+
+        # Wait for the host to be ready and get its PeerJS ID
+        host_id_handle = await host_page.wait_for_function("() => window.peer && window.peer.id", timeout=15000)
+        host_peer_id = await host_id_handle.json_value()
+        print(f"Host: PeerJS ID is '{host_peer_id}'")
+
+        # --- Companion Setup ---
+        companion_context = await browser.new_context()
+        companion_page = await companion_context.new_page()
+        companion_url = f"{index_path}?mode=companion&companion_id={host_peer_id}"
+        await companion_page.goto(companion_url)
+
+        # --- Verification: Modal Transfer ---
+        # On the companion, the "New Game" modal should now be visible.
+        await expect(companion_page.locator("#new-game-screen")).to_be_visible(timeout=15000)
+        print("Companion: 'New Game' modal is now visible.")
+
+        # On the host, the "New Game" modal should have been hidden.
+        await expect(host_page.locator("#new-game-screen")).to_be_hidden()
+        print("Host: 'New Game' modal is now hidden.")
+
+        # --- Verification: Game Start from Companion ---
+        # 1. Click "Standard" on the companion
+        await companion_page.locator("#new-game-standard").click()
+        await expect(companion_page.locator("#final-settings-screen")).to_be_visible()
+        print("Companion: Clicked 'Standard', final settings screen is visible.")
+
+        # 2. Click "Start Game" on the companion
+        await companion_page.locator("#final-settings-start-game-btn").click()
+
+        # 3. The game should start. On the companion, this means the app grid is visible.
+        await expect(companion_page.locator("#phone-apps-grid")).to_be_visible()
+        print("Companion: Game started, app grid is visible.")
+
+        # 4. On the host, the game UI should be active. We'll check the day display.
+        await expect(host_page.locator("#day-display")).to_have_text("1")
+        print("Host: Game started, UI is active.")
+
+        # --- Final Screenshot ---
+        screenshot_path = "jules-scratch/verification/companion_game_started.png"
+        await companion_page.screenshot(path=screenshot_path)
+        print(f"Verification successful. Screenshot saved to {screenshot_path}")
+
+        await browser.close()
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/jules-scratch/verification/verify_market_fix.py
+++ b/jules-scratch/verification/verify_market_fix.py
@@ -1,0 +1,66 @@
+import asyncio
+from playwright.async_api import async_playwright, expect
+import os
+import re
+
+async def main():
+    async with async_playwright() as p:
+        browser = await p.chromium.launch()
+        context = await browser.new_context()
+        host_page = await context.new_page()
+        companion_page = await context.new_page()
+
+        # 1. Go to the host page
+        file_path = os.path.abspath('index.html')
+        host_url = f'file://{file_path}'
+        await host_page.goto(host_url)
+
+        # 2. Start a default game directly on the host to bypass the new game modals
+        await host_page.evaluate("() => startGame({})")
+        print("✅ Default game started on host.")
+
+        # 3. Connect the companion
+        await host_page.click('#companion-sync-btn')
+        open_in_tab_btn = await host_page.wait_for_selector('#open-in-tab-btn:not(.hidden)')
+        companion_url = await open_in_tab_btn.get_attribute('href')
+        await companion_page.goto(companion_url)
+
+        # Wait for the handshake to complete
+        await expect(host_page.locator('#host-status')).to_have_text('✅ Connected!', timeout=10000)
+        await expect(companion_page.locator('#companion-status')).to_have_text('✅ Connected!', timeout=10000)
+        print("✅ Host and companion connected.")
+
+        # 4. Open the Market Panel from the host
+        await host_page.evaluate("() => openClipboardPanel()")
+        await host_page.click('#app-btn-market')
+        print("Host clicked 'Market' app.")
+
+        # 5. Verify the Market Panel is visible and populated on the companion
+        market_panel_companion = companion_page.locator('#market-panel')
+        await expect(market_panel_companion).to_be_visible(timeout=5000)
+
+        # Check that it's populated by looking for the first category button
+        first_category_button = companion_page.locator('button[id^="market-category-"]').first
+        await expect(first_category_button).to_be_visible(timeout=5000)
+        print("✅ Market panel is visible and populated on companion.")
+
+        # 6. Navigate to the Detail Panel on the companion
+        await first_category_button.click()
+        market_detail_panel_companion = companion_page.locator('#market-detail-panel')
+        await expect(market_detail_panel_companion).to_be_visible(timeout=5000)
+        await expect(market_panel_companion).to_be_hidden()
+
+        # 7. Assert that the detail panel is populated with item buttons
+        first_item_button = companion_page.locator('button[id^="market-item-"]').first
+        await expect(first_item_button).to_be_visible(timeout=5000)
+        print("✅ Market detail panel is visible and populated on companion.")
+
+        # 8. Take a screenshot for visual confirmation
+        screenshot_path = 'jules-scratch/verification/verification.png'
+        await companion_page.screenshot(path=screenshot_path)
+        print(f"📸 Screenshot saved to {screenshot_path}")
+
+        await browser.close()
+
+if __name__ == '__main__':
+    asyncio.run(main())

--- a/jules-scratch/verify_and_debug_market_fix.py
+++ b/jules-scratch/verify_and_debug_market_fix.py
@@ -1,0 +1,62 @@
+import asyncio
+import os
+from playwright.async_api import async_playwright, expect
+
+async def main():
+    # Setup
+    port = os.environ.get("PORT", "8000")
+    host_url = f"http://localhost:{port}/index.html"
+
+    async with async_playwright() as p:
+        # Launch browser
+        browser = await p.chromium.launch(headless=True)
+        context = await browser.new_context()
+
+        # Host page
+        host_page = await context.new_page()
+        await host_page.goto(host_url)
+
+        # DEBUG: Save host HTML to diagnose visibility issue
+        await host_page.wait_for_timeout(1000) # Give scripts time to run
+        host_html = await host_page.content()
+        with open("jules-scratch/host_page.html", "w") as f:
+            f.write(host_html)
+        print("📝 Host HTML saved to jules-scratch/host_page.html")
+
+        # This is the line that is expected to fail.
+        # The HTML snapshot from the previous step will help debug why.
+        await host_page.click('#new-game-btn')
+        print("✅ Clicked 'Start New Game' on host.")
+
+        # The rest of the script won't be reached, but is kept for context
+        await host_page.click('#final-settings-new-game-btn')
+        await expect(host_page.locator('#day-counter')).to_be_visible()
+        print("✅ Default game started on host.")
+
+        # Companion setup...
+        companion_url = f"{host_url}?companion=true"
+        await host_page.click('#companion-app-btn')
+        host_code_element = host_page.locator('#host-code')
+        await expect(host_code_element).to_be_visible()
+        host_code = await host_code_element.input_value()
+
+        companion_page = await context.new_page()
+        await companion_page.goto(companion_url)
+        await companion_page.fill('#companion-code-input', host_code)
+        await companion_page.click('#connect-btn')
+        await expect(companion_page.locator('#phone-ui')).to_be_visible(timeout=10000)
+
+        await host_page.click('#close-companion-code-btn')
+        market_app_host = host_page.locator('#app-icon-market')
+        await market_app_host.click()
+
+        market_panel_companion = companion_page.locator('#market-panel')
+        await expect(market_panel_companion).to_be_visible(timeout=5000)
+
+        item_row = market_panel_companion.locator('.grid-cols-4').first
+        await expect(item_row).to_be_visible()
+
+        await browser.close()
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/jules-scratch/verify_companion_modals.py
+++ b/jules-scratch/verify_companion_modals.py
@@ -1,0 +1,75 @@
+import asyncio
+import re
+from playwright.async_api import async_playwright, expect
+import os
+
+async def main():
+    async with async_playwright() as p:
+        browser = await p.chromium.launch(headless=True)
+
+        # Get the absolute path for the index.html file
+        index_path = "file://" + os.path.abspath("index.html")
+
+        # --- Host Setup ---
+        host_context = await browser.new_context()
+        host_page = await host_context.new_page()
+        await host_page.goto(index_path)
+
+        # The "New Game" modal should be visible on the host initially
+        await expect(host_page.locator("#new-game-screen")).to_be_visible()
+        print("Host: Initial 'New Game' modal is visible.")
+
+        # Click the companion sync button to open the QR code modal
+        # Force the click because the "New Game" modal may be obscuring it.
+        await host_page.locator("#companion-sync-btn").click(force=True)
+        await expect(host_page.locator("#host-sync-modal")).to_be_visible()
+        print("Host: QR code modal is visible.")
+
+        # Wait for the host to be ready and get its PeerJS ID
+        host_id_handle = await host_page.wait_for_function("() => window.peer && window.peer.id")
+        host_peer_id = await host_id_handle.json_value()
+        print(f"Host: PeerJS ID is '{host_peer_id}'")
+
+        # --- Companion Setup ---
+        companion_context = await browser.new_context()
+        companion_page = await companion_context.new_page()
+        companion_url = f"{index_path}?mode=companion&companion_id={host_peer_id}"
+        await companion_page.goto(companion_url)
+
+        # --- Verification: Modal Transfer ---
+        # The companion sends a 'ready' signal. The host should react by transferring the modal.
+
+        # On the companion, the "New Game" modal should now be visible.
+        await expect(companion_page.locator("#new-game-screen")).to_be_visible(timeout=15000)
+        print("Companion: 'New Game' modal is now visible.")
+
+        # On the host, the "New Game" modal should have been hidden.
+        await expect(host_page.locator("#new-game-screen")).to_be_hidden()
+        print("Host: 'New Game' modal is now hidden.")
+
+        # --- Verification: Game Start from Companion ---
+        # 1. Click "Standard" on the companion
+        await companion_page.locator("#new-game-standard").click()
+        await expect(companion_page.locator("#final-settings-screen")).to_be_visible()
+        print("Companion: Clicked 'Standard', final settings screen is visible.")
+
+        # 2. Click "Start Game" on the companion
+        await companion_page.locator("#final-settings-start-game-btn").click()
+
+        # 3. The game should start. On the companion, this means the app grid is visible.
+        await expect(companion_page.locator("#phone-apps-grid")).to_be_visible()
+        print("Companion: Game started, app grid is visible.")
+
+        # 4. On the host, the game UI should be active. We'll check the day display.
+        await expect(host_page.locator("#day-display")).to_have_text("1")
+        print("Host: Game started, UI is active.")
+
+        # --- Final Screenshot ---
+        screenshot_path = "jules-scratch/companion_game_started.png"
+        await companion_page.screenshot(path=screenshot_path)
+        print(f"Verification successful. Screenshot saved to {screenshot_path}")
+
+        await browser.close()
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/jules-scratch/verify_market_modal.py
+++ b/jules-scratch/verify_market_modal.py
@@ -1,0 +1,74 @@
+import asyncio
+import re
+from playwright.async_api import async_playwright, expect
+import os
+
+async def main():
+    async with async_playwright() as p:
+        browser = await p.chromium.launch(headless=True)
+
+        # Get the absolute path for the index.html file
+        # This is robust to wherever the script is run from.
+        index_path = "file://" + os.path.abspath("index.html")
+
+        # --- Host Setup ---
+        host_page = await browser.new_page()
+        await host_page.goto(index_path)
+
+        # Wait for the host to be ready and get its PeerJS ID
+        host_id = await host_page.wait_for_function("() => window.peer && window.peer.id")
+        host_peer_id = await host_id.json_value()
+        print(f"Host PeerJS ID: {host_peer_id}")
+
+        # --- Companion Setup ---
+        companion_page = await browser.new_page()
+        companion_url = f"{index_path}?mode=companion&companion_id={host_peer_id}"
+        await companion_page.goto(companion_url)
+
+        # Wait for the companion to confirm connection
+        await expect(companion_page.locator("#companion-status")).to_have_text("✅ Connected!")
+        print("Companion connected to host.")
+
+        # --- Start Game on Host ---
+        # The host will receive a 'companion-ready' signal and might show a modal.
+        # We need to click the button on the *companion* to start the game.
+        await companion_page.locator("#new-game-standard").click()
+        await asyncio.sleep(1) # Give a moment for the next screen to appear
+        await companion_page.locator("#final-settings-start-game-btn").click()
+        print("New game started via companion.")
+
+        # Wait for the game to be fully loaded on the companion
+        await expect(companion_page.locator("#phone-apps-grid")).to_be_visible()
+        print("Companion UI is ready.")
+
+        # --- Verification Steps on Companion ---
+
+        # 1. Open the Market app
+        await companion_page.locator("#app-btn-market").click()
+        await expect(companion_page.locator("#market-panel")).to_be_visible()
+        print("Market panel opened on companion.")
+
+        # 2. Click on the "Drawing" category to open the detail panel
+        # The button ID is dynamically generated, so we target it carefully.
+        await companion_page.locator("#market-category-0").click()
+        await expect(companion_page.locator("#market-detail-panel")).to_be_visible()
+        print("Market detail panel for 'Drawing' opened.")
+
+        # 3. Verify the panel is populated
+        # We'll check if the panel contains a button for one of the items in that category, e.g., "Pencil".
+        # This proves the `storageCells` data was correctly received and rendered.
+        item_button_locator = companion_page.locator("#market-item-Drawing-0") # This corresponds to the first item in the Drawing category
+
+        await expect(item_button_locator).to_be_visible(timeout=10000)
+        await expect(item_button_locator).to_contain_text("Pencil")
+        print("Verification successful: Market detail panel is populated with item data.")
+
+        # Take a screenshot for final confirmation
+        screenshot_path = "jules-scratch/companion_market_modal_populated.png"
+        await companion_page.screenshot(path=screenshot_path)
+        print(f"Screenshot saved to {screenshot_path}")
+
+        await browser.close()
+
+if __name__ == "__main__":
+    asyncio.run(main())


### PR DESCRIPTION
This feature implements the transfer of pop-up modals, such as the 'New Game' and 'Market Report' screens, from the host to a connected companion device.

- Modifies the `showScreen` and `hideScreen` functions to manage a `currentModalScreen` state variable.
- This state is synchronized with the companion via the `sendFullGameStateToCompanion` function.
- The companion's `applyGameState` function now reads this state to display the correct modal, hiding the main phone UI when a modal is active.
- This allows for a more focused user experience on the companion device, which now handles all modal interactions.