### PR TITLE
feat: Hide companion sync modal on connection

### DIFF
--- a/index.html
+++ b/index.html
@@ -9090,6 +9090,10 @@ function openProductAssignmentForShelf(shelf, slotIndex) {
                 document.getElementById('host-status').textContent = '✅ Connected!';
                 document.getElementById('companion-sync-btn').classList.add('phone-connected');
 
+                // Add a short delay to show the connected message, then hide the modal.
+                setTimeout(() => {
+                    hideScreen('host-sync-modal');
+                }, 1000);
 
                 // This map links button IDs from the companion to functions on the host.
                 // This is more reliable than simulating clicks.


### PR DESCRIPTION
This change automatically hides the host's companion sync modal 1 second after a successful connection is established.

This provides a clear visual cue to the user that the companion is ready and they can continue playing, improving the overall user experience of the connection flow.